### PR TITLE
Add ability to assign HotKeys to Nuke Menu entries.

### DIFF
--- a/python/tk_nuke/menu_generation.py
+++ b/python/tk_nuke/menu_generation.py
@@ -270,7 +270,8 @@ class AppCommand(object):
         """
         # std shotgun menu
         icon = self.properties.get("icon")
-        if self.properties.get("hotkey"):
+        hotkey = self.properties.get("hotkey")
+        if hotkey:
             menu.addCommand(self.name, self.callback, hotkey, icon=icon) 
         else:
             menu.addCommand(self.name, self.callback, icon=icon) 


### PR DESCRIPTION
Users asked if it were possible to assign a hotkey to the
'snapshot/snapshot as' entries. This appeared to be the
correct place to implement this feature.wq
