### PR TITLE
Favourites Directories

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -150,6 +150,7 @@ class NukeEngine(tank.platform.Engine):
 
             self._menu_generator = tk_nuke.MenuGenerator(self, menu_name)
             self._menu_generator.create_menu()
+            
             self.__setup_favourite_dirs()
             
         # iterate over all apps, if there is a gizmo folder, add it to nuke path
@@ -237,39 +238,48 @@ class NukeEngine(tank.platform.Engine):
         supported_entity_types = ["Shot", "Sequence", "Scene", "Asset", "Project"]
         for x in supported_entity_types:
             nuke.removeFavoriteDir("Tank Current %s" % x)
-
-        # new style favourites are simply "Tank Current Project" and "Tank Current Work"
         
-        # with the rename, make sure the old 'Tank' directories are removed:
-        nuke.removeFavoriteDir("Tank Current Project")
-        nuke.removeFavoriteDir("Tank Current Work")
-        # and then use the newer, new 'Shotgun' directories:
-        nuke.removeFavoriteDir("Shotgun Current Project")
-        nuke.removeFavoriteDir("Shotgun Current Work")
-
-        # we only present these shortcuts if there is exactly one path resolving to the work
-        # area or the project - otherwise it is just confusing!
-
-        # handle the project
-        if self.context.project:
-            proj = self.context.project
-            paths = self.tank.paths_from_entity(proj["type"], proj["id"])
-            if len(paths) == 1:
-                p = paths[0]
-                nuke.addFavoriteDir("Shotgun Current Project", 
-                                    directory=p,  
-                                    type=(nuke.IMAGE|nuke.SCRIPT|nuke.GEO), 
-                                    icon=tank_logo_small, 
-                                    tooltip=p)
-
-        # handle the current work
-        paths = self.context.filesystem_locations
-        if len(paths) == 1:
-            p = paths[0]            
-            nuke.addFavoriteDir("Shotgun Current Work", 
-                                directory=p,  
+        #handle project
+        proj = self.context.project
+        paths = self.tank.paths_from_entity(proj["type"], proj["id"])
+        pipeline_config=tank.pipelineconfig.from_path(paths[0])
+        for path in paths:
+            
+            #getting root names if the paths are the same
+            dirname='Unknown Path'
+            if path in pipeline_config.get_data_roots().values():
+                
+                #comparing roots paths with input path
+                for rootname, rootpath in pipeline_config.get_data_roots().items():
+                    if rootpath == path:
+                        dirname=rootname
+            
+            #removing old directory
+            nuke.removeFavoriteDir(dirname)
+            
+            #adding new path
+            nuke.addFavoriteDir(dirname, 
+                                directory=path,  
                                 type=(nuke.IMAGE|nuke.SCRIPT|nuke.GEO), 
                                 icon=tank_logo_small, 
+                                tooltip=path)
+        
+        #handle favourites directories
+        for directory in self.get_setting("favorite_directories"):
+            
+            #removing old directory
+            nuke.removeFavoriteDir(directory['display_name'])
+            
+            #getting paths from context
+            template=self.get_template_by_name(directory['directory'])
+            fields=self.context.as_template_fields(template)
+            p=template.apply_fields(fields)
+            
+            #adding new directory
+            nuke.addFavoriteDir(directory['display_name'], 
+                                directory=p,  
+                                type=(nuke.IMAGE|nuke.SCRIPT|nuke.GEO), 
+                                icon=directory['icon'], 
                                 tooltip=p)
         
     ##########################################################################################

--- a/info.yml
+++ b/info.yml
@@ -12,6 +12,23 @@
 
 # expected fields in the configuration file for this engine
 configuration:
+
+    favorite_directories:
+        type: list
+        values:
+            type: dict
+            items:
+                display_name:
+                    type: str
+                    description: Name of shortcut in favourites menu.
+                directory:
+                    type: template
+                    description: Directory of shortcut in favourites menu.
+                icon:
+                    type: config_path
+                    description: Icon of shotcut in favourites menu.
+        default_value: []
+
     debug_logging: 
         type: bool
         description: Controls whether debug messages should be emitted to the logger


### PR DESCRIPTION
Support for custom favourites shortcuts.

Issues and thoughts:
- default_value for 'favourite_directories' doesnt seem to work, engine validation return str and not list
- dont know how this setup will do on a non-multiroot system
- cant get the default value for the icon to work, doesnt seem to pick up the value
- possibly need some special cases if people want to use versions etc. that arent part of the app initialization
- refine paths in tk-multi-workfiles:
  - support the templates to have optional fields, that can be populated when the data is present. which could be the versions etc.
