### PR TITLE
22785 add favorite dirs

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -12,14 +12,36 @@
 
 # expected fields in the configuration file for this engine
 configuration:
+
+    favourite_directories:
+        type: list
+        description: Adds entries to the favourites section in the file chooser.
+        values:
+            type: dict
+            items:
+                display_name:
+                    type: str
+                    description: Name of shortcut in favourites section of the file chooser.
+                template_directory:
+                    type: template
+                    fields: context
+                    description: Template path for the shortcut in favourites section.
+                icon:
+                    type: config_path
+                    description: "Path to icon for the favourite relative to the project config 
+                                 directory. You can use the default icon by specifying an
+                                 empty string with two double quotes."
+        default_value: []
+        allows_empty: true
+
     debug_logging: 
         type: bool
         description: Controls whether debug messages should be emitted to the logger
         default_value: false
-        
+
     menu_favourites:
         type: list
-        description: "Controls the favourites section on the main menu. This is a list 
+        description: "Controls the favourites section on the main menu. This is a list
                      and each menu item is a dictionary with keys app_instance and name.
                      The app_instance parameter connects this entry to a particular
                      app instance defined in the environment configuration file. The name


### PR DESCRIPTION
- Modified version of #5. Allows configuring favorite directories in the Nuke file chooser.
- Rename 'favourite' to American spelling where possible. 

This currently does not support showing the current work area favorite if multiple filesystem locations exist for the context. It will display the favorite if a single filesystem location exists however. 
