### PR TITLE
env switch to disable the nuke message at engine start up

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -102,7 +102,7 @@ class NukeEngine(tank.platform.Engine):
                    % (nuke.env.get("NukeVersionMajor"), nuke.env.get("NukeVersionMinor"), nuke.env.get("NukeVersionRelease")))
             
             # show nuke message if in UI mode and this is the first time the engine has been started:
-            if self._ui_enabled and not "TANK_NUKE_ENGINE_INIT_NAME" in os.environ:
+            if self._ui_enabled and not "TANK_NUKE_ENGINE_INIT_NAME" in os.environ and self.get_setting("show_version_warning"):
                 nuke.message("Warning - Shotgun Pipeline Toolkit!\n\n%s" % msg)
                            
             # and log the warning

--- a/info.yml
+++ b/info.yml
@@ -57,6 +57,11 @@ configuration:
         type: bool
         description: Optionally choose to use 'Sgtk' as the primary menu name instead of 'Shotgun'
         default_value: false
+
+    show_version_warning:
+        type: bool
+        description: Disable the nuke message dialog at engine start up
+        default_value: true
                      
     
 # the Shotgun fields that this engine needs in order to operate correctly


### PR DESCRIPTION
Hey,

I know you put this for a reason, still I believe one should be able to turn it off.

Cheers
Johannes