### PR TITLE
#25794 Add setting to disable or rename current project root favorite directory

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -222,8 +222,10 @@ class NukeEngine(tank.platform.Engine):
 
         # add favorties for current project root(s)
         proj = self.context.project
-        current_proj_fav = self.get_setting("current_project_favourite_name")
-        if proj:
+        current_proj_fav = self.get_setting("project_favourite_name")
+        # only add these current project entries if we have a value from settings.
+        # Otherwise, they have opted to not show them.
+        if proj and current_proj_fav:
             proj_roots = self.tank.roots
             for root_name, root_path in proj_roots.items():
                 dir_name = current_proj_fav
@@ -233,15 +235,12 @@ class NukeEngine(tank.platform.Engine):
                 # remove old directory
                 nuke.removeFavoriteDir(dir_name)
             
-                # only add a new entry if we have a value from settings.
-                # Otherwise, they have opted to not show these menus.
-                if current_proj_fav:
-                    # add new path
-                    nuke.addFavoriteDir(dir_name, 
-                                        directory=root_path,  
-                                        type=(nuke.IMAGE|nuke.SCRIPT|nuke.GEO), 
-                                        icon=tank_logo_small, 
-                                        tooltip=root_path)
+                # add new path
+                nuke.addFavoriteDir(dir_name, 
+                                    directory=root_path,  
+                                    type=(nuke.IMAGE|nuke.SCRIPT|nuke.GEO), 
+                                    icon=tank_logo_small, 
+                                    tooltip=root_path)
 
         # add favorites directories from the config
         for favorite in self.get_setting("favourite_directories"):

--- a/info.yml
+++ b/info.yml
@@ -34,7 +34,7 @@ configuration:
         default_value: []
         allows_empty: true
 
-    current_project_favourite_name:
+    project_favourite_name:
         type: str
         description: "Allows customizing the name of the favourite directory representing
                      the current project root in the file chooser. eg. 'Shotgun Current Project'. 


### PR DESCRIPTION
Currently we automatically add a favourite directory entry to the file chooser for the project root. These look like "Shotgun Project Root". Multi-root setups have an entry for each root like this: "Shotgun Project Root (secondary)", etc. This can be quite redundant so some studios. And the name of the favourite is quite lengthy. This can make things cluttered in that pane in the file chooser.

This code adds a setting `current_project_favourite_name` allowing you to rename the menu to anything you like (in multi-root setups, the root name will still be automatically added on to the end of the name). Additionally, if you specify an empty string `''` as the value, this will disable adding the menu to the favorites pane.
