### PR TITLE
Avoid destroy_menu to raise when a Menu is already empty

### DIFF
--- a/python/tk_nuke/menu_generation.py
+++ b/python/tk_nuke/menu_generation.py
@@ -391,7 +391,7 @@ class NukeMenuGenerator(BaseMenuGenerator):
             # Find the menu and iterate over all items.
             for mh in nuke.menu(menu).items():
                 # Look for the shotgun menu.
-                if mh.name() == self._menu_name:
+                if isinstance(mh, nuke.Menu) and mh.name() == self._menu_name:
                     # Clear it.
                     mh.clearMenu()
 


### PR DESCRIPTION
```python
[13:05.57] ERROR: Shotgun Error: Could not restart the engine!

'MenuItem' object has no attribute 'clearMenu'
The current environment is shot_step.

Code Traceback:
  File ".../studio/install/core/python/tank/platform/__init__.py", line 109, in restart
    engine.destroy()
  File ".../studio/install/core/python/tank/platform/engine.py", line 435, in destroy
    self.destroy_engine()
  File ".../studio/install/engines/app_store/tk-nuke/v0.4.1/engine.py", line 246, in destroy_engine
    self._menu_generator.destroy_menu()
  File ".../studio/install/engines/app_store/tk-nuke/v0.4.1/python/tk_nuke/menu_generation.py", line 396, in destroy_menu
    mh.clearMenu()
```

To avoid this error when a menu (Nuke, Pane or Node) is already empty.