### PR TITLE
fix menu generation if self._menu_name is a MenuItem

### DIFF
--- a/python/tk_nuke/menu_generation.py
+++ b/python/tk_nuke/menu_generation.py
@@ -559,6 +559,10 @@ class NukeMenuGenerator(BaseMenuGenerator):
         menus = ["Nuke", "Pane", "Nodes"]
         for menu in menus:
             # Find the menu and iterate over all items.
+            
+            # remove self.menu_name if exist as MenuItem
+            nuke.menu(menu).removeItem(self._menu_name)
+            
             for mh in nuke.menu(menu).items():
                 # Look for the shotgun menu.
                 if mh.name() == self._menu_name:


### PR DESCRIPTION
I have some issue with destroy_menu
sometimes "Shotgun" is a MenuItem, not a Menu and clearMenu() call FAILED

Remove MenuItem named self._menu_name before clearMenu prevent this crash
Best Regards