### PR TITLE
Enhance __tank_startup_node_callback context modification

### DIFF
--- a/python/tk_nuke/__init__.py
+++ b/python/tk_nuke/__init__.py
@@ -152,19 +152,13 @@ def __tank_startup_node_callback():
             return
             
         if nuke.root().name() == "Root":
-            # file->new
-            # base it on the context we 'inherited' from the prev session
-            # get the context from the previous session - this is helpful if user does file->new
+            # file->new or clear
+            # load a default project context
             project_root = os.environ.get("TANK_NUKE_ENGINE_INIT_PROJECT_ROOT")
             tk = tank.Tank(project_root)
-            
-            ctx_str = os.environ.get("TANK_NUKE_ENGINE_INIT_CONTEXT")
-            if ctx_str:
-                try:
-                    new_ctx = tk.context_from_path(project_root, tk.context_empty())
-                except:
-                    new_ctx = tk.context_empty()
-            else:
+            try:
+                new_ctx = tk.context_from_path(project_root, tk.context_empty())
+            except:
                 new_ctx = tk.context_empty()
     
         else:
@@ -174,6 +168,7 @@ def __tank_startup_node_callback():
             try:
                 tk = tank.tank_from_path(file_name)
             except tank.TankError, e:
+                 # load a default project context
                 project_root = os.environ.get("TANK_NUKE_ENGINE_INIT_PROJECT_ROOT")
                 tk = tank.Tank(project_root)
                 file_name = project_root

--- a/python/tk_nuke/__init__.py
+++ b/python/tk_nuke/__init__.py
@@ -161,7 +161,7 @@ def __tank_startup_node_callback():
             ctx_str = os.environ.get("TANK_NUKE_ENGINE_INIT_CONTEXT")
             if ctx_str:
                 try:
-                    new_ctx = tank.context.deserialize(ctx_str)
+                    new_ctx = tk.context_from_path(project_root, tk.context_empty())
                 except:
                     new_ctx = tk.context_empty()
             else:
@@ -174,8 +174,9 @@ def __tank_startup_node_callback():
             try:
                 tk = tank.tank_from_path(file_name)
             except tank.TankError, e:
-                __create_tank_disabled_menu(e)
-                return
+                project_root = os.environ.get("TANK_NUKE_ENGINE_INIT_PROJECT_ROOT")
+                tk = tank.Tank(project_root)
+                file_name = project_root
                 
             # try to get current ctx and inherit its values if possible
             curr_ctx = None


### PR DESCRIPTION
Default behaviour in __tank_startup_node_callback is a little annoying

- If you load a file out of the pipe, Shotgun menu appears disabled and you can't open a pipeline file (instead of using file>open dialog which is not pipeline compliant)

- Another point, I found dangerous to inherited context from the previous session when you click on file>open. This behaviour could generate save with unwanted context.

To fix these two problems, I propose to switch on "project" context as default behaviour for file>new/clear and unsupported file
It enables open/inject dirty scene in the pipeline and never lose the shotgun menu

Best Regards
Yann