### PR TITLE
33062 Adds a call to log a user metric for the DCC version

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -226,6 +226,7 @@ class NukeEngine(tank.platform.Engine):
             # (several of the key scene callbacks are in the main init file).
             import tk_nuke
             import hiero
+            from hiero.core import env as hiero_env
 
             # Create the menu!
             self._menu_generator = tk_nuke.NukeStudioMenuGenerator(self, menu_name)
@@ -249,6 +250,13 @@ class NukeEngine(tank.platform.Engine):
                 self._handle_studio_selection_change,
             )
 
+            hiero_ver_str = "%s.%s%s" % (
+                hiero_env["VersionMajor"],
+                hiero_env["VersionMinor"],
+                hiero_env["VersionRelease"],
+            )
+            self.log_user_attribute_metric("Nuke Studio version", hiero_ver_str)
+
     def post_app_init_hiero(self, menu_name="Shotgun"):
         """
         The Hiero-specific portion of the engine's post-init process.
@@ -270,12 +278,20 @@ class NukeEngine(tank.platform.Engine):
                 self.set_project_root,
             )
 
+            hiero_ver_str = "%s.%s%s" % (
+                hiero_env["VersionMajor"],
+                hiero_env["VersionMinor"],
+                hiero_env["VersionRelease"],
+            )
+            self.log_user_attribute_metric("Hiero version", hiero_ver_str)
+
     def post_app_init_nuke(self, menu_name="Shotgun"):
         """
         The Nuke-specific portion of the engine's post-init process.
 
         :param menu_name:   The label/name of the menu to be created.
         """
+
         if self.has_ui and not self.studio_enabled:
             # Note! not using the import as this confuses Nuke's callback system
             # (several of the key scene callbacks are in the main init file).
@@ -314,6 +330,8 @@ class NukeEngine(tank.platform.Engine):
                 # new processes spawned from this one will have access too.
                 # (for example if you do file->open or file->new)
                 tank.util.append_path_to_env_var("NUKE_PATH", app_gizmo_folder)
+
+        self.log_user_attribute_metric("Nuke version", nuke.env.get("NukeVersionString"))
 
     def destroy_engine(self):
         """

--- a/engine.py
+++ b/engine.py
@@ -250,12 +250,16 @@ class NukeEngine(tank.platform.Engine):
                 self._handle_studio_selection_change,
             )
 
-            hiero_ver_str = "%s.%s%s" % (
-                hiero_env["VersionMajor"],
-                hiero_env["VersionMinor"],
-                hiero_env["VersionRelease"],
-            )
-            self.log_user_attribute_metric("Nuke Studio version", hiero_ver_str)
+            try:
+                hiero_ver_str = "%s.%s%s" % (
+                    hiero_env["VersionMajor"],
+                    hiero_env["VersionMinor"],
+                    hiero_env["VersionRelease"],
+                )
+                self.log_user_attribute_metric("Nuke Studio version", hiero_ver_str)
+            except:
+                # ignore all errors. ex: using a core that doesn't support metrics
+                pass
 
     def post_app_init_hiero(self, menu_name="Shotgun"):
         """
@@ -278,12 +282,16 @@ class NukeEngine(tank.platform.Engine):
                 self.set_project_root,
             )
 
-            hiero_ver_str = "%s.%s%s" % (
-                hiero_env["VersionMajor"],
-                hiero_env["VersionMinor"],
-                hiero_env["VersionRelease"],
-            )
-            self.log_user_attribute_metric("Hiero version", hiero_ver_str)
+            try:
+                hiero_ver_str = "%s.%s%s" % (
+                    hiero_env["VersionMajor"],
+                    hiero_env["VersionMinor"],
+                    hiero_env["VersionRelease"],
+                )
+                self.log_user_attribute_metric("Hiero version", hiero_ver_str)
+            except:
+                # ignore all errors. ex: using a core that doesn't support metrics
+                pass
 
     def post_app_init_nuke(self, menu_name="Shotgun"):
         """
@@ -331,7 +339,12 @@ class NukeEngine(tank.platform.Engine):
                 # (for example if you do file->open or file->new)
                 tank.util.append_path_to_env_var("NUKE_PATH", app_gizmo_folder)
 
-        self.log_user_attribute_metric("Nuke version", nuke.env.get("NukeVersionString"))
+        try:
+            self.log_user_attribute_metric("Nuke version",
+                nuke.env.get("NukeVersionString"))
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
 
     def destroy_engine(self):
         """

--- a/info.yml
+++ b/info.yml
@@ -147,4 +147,3 @@ description: "Shotgun Integration in Nuke"
 requires_shotgun_version:
 requires_core_version: "v0.17.0"
 
-# XXX will require core version with metrics logging

--- a/info.yml
+++ b/info.yml
@@ -147,3 +147,4 @@ description: "Shotgun Integration in Nuke"
 requires_shotgun_version:
 requires_core_version: "v0.17.0"
 
+# XXX will require core version with metrics logging


### PR DESCRIPTION
The call logs the metric internally and ignores any errors. This prevents the need to force the engine's users to update to a new core that supports metrics. When a supported core is updated, the metric will be logged.