### PR TITLE
#37034: Switches to using onScriptLoad rather than onCreate to handle context setting.

### DIFF
--- a/python/tk_nuke/__init__.py
+++ b/python/tk_nuke/__init__.py
@@ -138,7 +138,7 @@ def __tank_on_save_callback():
         __create_tank_error_menu()
 
 
-def __tank_startup_node_callback():    
+def tank_startup_node_callback():    
     """
     Callback that fires every time a node gets created.
     
@@ -147,9 +147,9 @@ def __tank_startup_node_callback():
     """    
     try:
         # look for the root node - this is created only when a new or existing file is opened.
-        tn = nuke.thisNode()
-        if tn != nuke.root():
-            return
+        # tn = nuke.thisNode()
+        # if tn != nuke.root():
+        #     return
             
         if nuke.root().name() == "Root":
             # file->new
@@ -197,7 +197,8 @@ def tank_ensure_callbacks_registered():
     """
     global g_tank_callbacks_registered
     if not g_tank_callbacks_registered:
-        nuke.addOnCreate(__tank_startup_node_callback)
+        # nuke.addOnCreate(__tank_startup_node_callback)
+        nuke.addOnScriptLoad(tank_startup_node_callback)
         nuke.addOnScriptSave(__tank_on_save_callback)
         g_tank_callbacks_registered = True
 

--- a/python/tk_nuke/__init__.py
+++ b/python/tk_nuke/__init__.py
@@ -145,12 +145,7 @@ def tank_startup_node_callback():
     Carefully manage exceptions here so that a bug in Tank never
     interrupts the normal workflows in Nuke.    
     """    
-    try:
-        # look for the root node - this is created only when a new or existing file is opened.
-        # tn = nuke.thisNode()
-        # if tn != nuke.root():
-        #     return
-            
+    try:    
         if nuke.root().name() == "Root":
             # file->new
             # base it on the context we 'inherited' from the prev session
@@ -197,7 +192,6 @@ def tank_ensure_callbacks_registered():
     """
     global g_tank_callbacks_registered
     if not g_tank_callbacks_registered:
-        # nuke.addOnCreate(__tank_startup_node_callback)
         nuke.addOnScriptLoad(tank_startup_node_callback)
         nuke.addOnScriptSave(__tank_on_save_callback)
         g_tank_callbacks_registered = True

--- a/startup/menu.py
+++ b/startup/menu.py
@@ -25,6 +25,7 @@ import sys
 def handle_new_tank_session():
     import tk_nuke
     tk_nuke.tank_ensure_callbacks_registered()
+    tk_nuke.tank_startup_node_callback()
 
 if not nuke.env.get("hiero"):
     # now we need to add our callback module to the pythonpath manually.


### PR DESCRIPTION
The combination of onScriptLoad plus calling the same logic from the menu.py handles setting the context both for script load and file->new actions. This reduces the number of events we're handling.