### PR TITLE
Adds a pick_environment hook call to avoid a potential raise.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -190,10 +190,17 @@ class NukeEngine(tank.platform.Engine):
 
         # Now check that there is a location on disk which corresponds to the context.
         if self.context.project is None:
-            # Must have at least a project in the context to even start!
-            raise tank.TankError("The nuke engine needs at least a project"
-                                 "in the context in order to start! Your "
-                                 "context: %s" % self.context)
+            if self.context:
+                # Use pick environment hook to determine current context
+                env_name = self.context.tank.execute_core_hook(
+                    tank.platform.constants.PICK_ENVIRONMENT_CORE_HOOK_NAME,
+                    context=self.context)
+
+                if not env_name:
+                    # Must have at least a project in the context to even start!
+                    raise tank.TankError("The nuke engine needs at least a project"
+                                         "in the context in order to start! Your "
+                                         "context: %s" % self.context)
 
         # Do our mode-specific initializations.
         if self.hiero_enabled:


### PR DESCRIPTION
This is a change provided by Mikros for ZD support ticket 71563. It's in response to a raise by the engine on context change if the context doesn't have an associated project. This appears to be the case when a .nk script is opened outside the context of the current SGTK project.