### PR TITLE
importing QtGui from sgtk.platform instead of PySide module.

### DIFF
--- a/python/tk_nuke/menu_generation.py
+++ b/python/tk_nuke/menu_generation.py
@@ -18,7 +18,7 @@ import unicodedata
 import nukescripts.openurl
 import nukescripts
 
-from PySide import QtGui
+from sgtk.platform.qt import QtGui
 
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
Importing QtGui from the PySide module breaks this engine in Nuke 11 since they have moved from PySide to PySide2.