### PR TITLE
For #43349: Highjacks the launch to force an engine instance for Nuke Studio.

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -263,7 +263,9 @@ class NukeLauncher(SoftwareLauncher):
             )
             # Add context information info to the env.
             required_env["TANK_CONTEXT"] = sgtk.Context.serialize(self.context)
-            required_env["TANK_ENGINE"] = self.engine_name
+
+            if "TANK_ENGINE" not in required_env:
+                required_env["TANK_ENGINE"] = self.engine_name
 
         self.logger.debug("Launch environment: %s", pprint.pformat(required_env))
         self.logger.debug("Launch arguments: %s", required_args)
@@ -362,6 +364,13 @@ class NukeLauncher(SoftwareLauncher):
             env["HIERO_PLUGIN_PATH"] = cls._join_paths_with_existing_env_paths("HIERO_PLUGIN_PATH", startup_paths)
         elif "nukestudio" in app_path.lower() or "--studio" in app_args:
             env["HIERO_PLUGIN_PATH"] = cls._join_paths_with_existing_env_paths("HIERO_PLUGIN_PATH", startup_paths)
+
+            # A bit of magic here. Since we know we're in a classic config, we also know
+            # that Nuke Studio is configured differently than Nuke. Because of that, and
+            # because we have a single Software entity for the Nuke family of products,
+            # we highjack the process here and direct the launch towards the tk-nukestudio
+            # engine instance.
+            env["TANK_ENGINE"] = "tk-nukestudio"
         else:
             env["NUKE_PATH"] = cls._join_paths_with_existing_env_paths("NUKE_PATH", startup_paths)
 

--- a/startup.py
+++ b/startup.py
@@ -291,7 +291,11 @@ class NukeLauncher(SoftwareLauncher):
             to specify.
         """
         return cls._compute_environment(
-            app_path, app_args, [os.path.join(bundle_root, "classic_startup")], file_to_open
+            app_path,
+            app_args,
+            [os.path.join(bundle_root, "classic_startup")],
+            file_to_open,
+            is_classic=True,
         )
 
     def _get_plugin_startup_env(self, plugin_names, app_path, app_args, file_to_open):
@@ -344,7 +348,7 @@ class NukeLauncher(SoftwareLauncher):
         return os.pathsep.join(filter(None, new_path_list))
 
     @classmethod
-    def _compute_environment(cls, app_path, app_args, startup_paths, file_to_open):
+    def _compute_environment(cls, app_path, app_args, startup_paths, file_to_open, is_classic=False):
         """
         Computes the environment variables and command line arguments required to launch Nuke.
 
@@ -352,6 +356,8 @@ class NukeLauncher(SoftwareLauncher):
         :param str app_args: Arguments for the app being launched.
         :param list startup_paths: List of paths to plugins that need to be added to the DCC's path.
         :param str file_to_open: Path to a file to open.
+        :param bool is_classic: Whether we're computing an environment for a classic config or not.
+            Default is False.
 
         :returns: Dictionary of environment variables to set and the command line arguments
             to specify.
@@ -370,7 +376,8 @@ class NukeLauncher(SoftwareLauncher):
             # because we have a single Software entity for the Nuke family of products,
             # we highjack the process here and direct the launch towards the tk-nukestudio
             # engine instance.
-            env["TANK_ENGINE"] = "tk-nukestudio"
+            if is_classic:
+                env["TANK_ENGINE"] = "tk-nukestudio"
         else:
             env["NUKE_PATH"] = cls._join_paths_with_existing_env_paths("NUKE_PATH", startup_paths)
 

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -274,12 +274,21 @@ class TestStartup(TankTestBase):
 
     def _get_hiero_environment(self, is_classic=True):
         """
-        Returns the expected environment variables dictionary for Hiero or Nuke Studio
+        Returns the expected environment variables dictionary for Hiero
         """
         if is_classic:
             env = self._get_classic_environment("HIERO_PLUGIN_PATH")
         else:
             env = self._get_plugin_environment("HIERO_PLUGIN_PATH")
+        return env
+
+    def _get_studio_environment(self, is_classic=True):
+        """
+        Returns the expected environment variables dictionary for Nuke Studio
+        """
+        env = self._get_hiero_environment(is_classic)
+        if is_classic:
+            env["TANK_ENGINE"] = "tk-nukestudio"
         return env
 
     def _get_nuke_environment(self, is_classic=True):
@@ -306,12 +315,12 @@ class TestStartup(TankTestBase):
         for engine_instance, is_classic in self._get_engine_configurations():
             self._test_launch_information(
                 engine_instance, "NukeStudio.app", "", None,
-                self._get_hiero_environment(is_classic=is_classic)
+                self._get_studio_environment(is_classic=is_classic)
             )
 
             self._test_launch_information(
                 engine_instance, "Nuke.exe", "--studio", None,
-                self._get_hiero_environment(is_classic=is_classic)
+                self._get_studio_environment(is_classic=is_classic)
             )
 
     def test_nuke(self):


### PR DESCRIPTION
This resolves the problem of us providing a single Software entity for the Nuke family of products, but needing different configuration for Nuke Studio as compared to Nuke.

This is considered a medium-term fix, as Rob and I have discussed a Product->engine_instance map likely controlled via launchapp hook. That will require more work than can be done right this moment, so this is the fix for the time being.