### PR TITLE
SPLAT-83: Added methods to retrieve script path and dependencies.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -925,6 +925,7 @@ class NukeEngine(tank.platform.Engine):
         :returns: Path to the current session if it has been saved to disk,
                   else returns None.
         """
+
         if self.hiero_enabled or self.studio_enabled:
             import hiero
 
@@ -937,9 +938,8 @@ class NukeEngine(tank.platform.Engine):
             # only one selection.
             if len(selection) != 1:
                 hiero.core.log.error("Cannot determine the current session " +
-                                     "dependencies as the selected project " +
-                                     "could not be deduced from 0 or multiple " +
-                                     "selections.")
+                                     "filename as a single project selection " +
+                                     "is required to do so.")
                 return None
 
             # if the user has selected a non-project element,
@@ -956,9 +956,8 @@ class NukeEngine(tank.platform.Engine):
                 # apparently bins can be without projects (child bins)
                 hiero.core.log.error("Cannot determine the current session " +
                                      "as the project could not be deduced.")
-                return None
-
-            session_path = project.path()
+            else:
+                session_path = project.path()
         else:
             session_path = nuke.root().knob("name").value()
 
@@ -1000,45 +999,40 @@ class NukeEngine(tank.platform.Engine):
             # only one selection.
             if len(selection) != 1:
                 hiero.core.log.error("Cannot determine the current session " +
-                                     "dependencies as the selected project " +
-                                     "could not be deduced from 0 or multiple " +
-                                     "selections.")
-                return []
-
-            # if the user has selected a non-project element,
-            # return None
-            if not isinstance(selection[0], hiero.core.Bin):
+                                     "dependencies as a single project selection " +
+                                     "is required to do so.")
+            # if the user has selected a non-project element, return an
+            # empty list
+            elif not isinstance(selection[0], hiero.core.Bin):
                 hiero.core.log.error("Cannot determine the current session " +
                                      "dependencies because an element other " +
                                      "than a project is selected.")
-                return []
+            else:
+                project = selection[0].project()
 
-            project = selection[0].project()
-
-            if project is None:
-                # apparently bins can be without projects (child bins)
-                hiero.core.log.error("Cannot determine the current session " +
-                                     "dependencies as the project could not " +
-                                     "be deduced from the selection.")
-                return []
-
-            # collect dependencies for the selected project.
-            for clip in project.clips():
-                mediaSource = clip.mediaSource()
-                for info in mediaSource.fileinfos():
-                    # replace forward slashes with the OS-
-                    # specific path separator to make
-                    # Nuke happy on Windows.
-                    dependencies.append(
-                        {
-                            "path": info.filename().replace(
-                                "/",
-                                os.path.sep
-                            ),
-                            "engine": self.name,
-                            "type": "MediaSource",
-                        }
-                    )
+                if project is None:
+                    # apparently bins can be without projects (child bins)
+                    hiero.core.log.error("Cannot determine the current session " +
+                                         "dependencies as the project could not " +
+                                         "be deduced from the selection.")
+                else:
+                    # collect dependencies for the selected project.
+                    for clip in project.clips():
+                        mediaSource = clip.mediaSource()
+                        for info in mediaSource.fileinfos():
+                            # replace forward slashes with the OS-
+                            # specific path separator to make
+                            # Nuke happy on Windows.
+                            dependencies.append(
+                                {
+                                    "path": info.filename().replace(
+                                        "/",
+                                        os.path.sep
+                                    ),
+                                    "engine": self.name,
+                                    "type": "MediaSource",
+                                }
+                            )
         else:
             # create a list of Read-like nodes in the session
             read_nodes = [node for node in nuke.allNodes()

--- a/engine.py
+++ b/engine.py
@@ -927,9 +927,7 @@ class NukeEngine(tank.platform.Engine):
         # retrieve the name of the nuke file. In case of a saved file, the
         # absolute path of the file is returned, for an unsaved file,
         # an empty string is returned.
-        path = nuke.root().knob("name").value()
-
-        return path
+        return nuke.root().knob("name").value()
 
     def get_session_dependencies(self):
         """
@@ -945,8 +943,13 @@ class NukeEngine(tank.platform.Engine):
         start_frame = int(nuke.root().knob("first_frame").value())
         end_frame = int(nuke.root().knob("last_frame").value())
 
-        # retrieve the enabled Write nodes
-        enabled_write_nodes = self._get_enabled_write_nodes()
+        # create a list of enabled write node in the session
+        enabled_write_nodes = []
+        write_nodes = [node for node in nuke.allNodes()
+                       if node.Class() == "Write"]
+        if write_nodes:
+            enabled_write_nodes = [node for node in write_nodes
+                                   if not node.knob("disable").value()]
 
         # find file dependencies for each write node
         for write_node in enabled_write_nodes:

--- a/engine.py
+++ b/engine.py
@@ -1028,4 +1028,10 @@ class NukeEngine(tank.platform.Engine):
                         }
                     )
 
-        return dependencies
+        # apply any custom filtering before returning
+        # the list of dependency data.
+        return self.execute_hook_method(
+            "hook_filter_dependencies",
+            "filter_dependencies",
+            dependencies=dependencies
+        )

--- a/engine.py
+++ b/engine.py
@@ -922,7 +922,7 @@ class NukeEngine(tank.platform.Engine):
         disk. If unsaved, it returns None.
 
         :return: Path to the current scene if file is saved, else returns
-                 and empty string..
+                 and empty string.
         """
         # retrieve the name of the nuke file. In case of a saved file, the
         # absolute path of the file is returned, for an unsaved file,

--- a/engine.py
+++ b/engine.py
@@ -916,16 +916,14 @@ class NukeEngine(tank.platform.Engine):
     #####################################################################################
     # Script and session related methods
 
-    def get_session_path(self, session=None):
+    def get_session_path(self):
         """
-        Returns the absolute path to the current file if it resides
+        Returns the absolute path to the current session if it resides
         on disk. If the session has never been saved and isn't
         associated with a file on disk yet, an empty string is returned.
 
-        :param session: An object representing the active document
-                        (for MDI applications).
-        :returns: Path to the current file if it has been saved to disk,
-                  else returns an empty string.
+        :returns: Path to the current session if it has been saved to disk,
+                  else returns None.
         :raises TankError: Raises a `TankError` if the application is
                            unable to determine the session that is
                            being referred to.
@@ -957,14 +955,15 @@ class NukeEngine(tank.platform.Engine):
 
         # replace forward slashes with the OS-specific path separator
         # to make Nuke happy on Windows.
-        return session_path.replace("/", os.path.sep)
+        session_path = session_path.replace("/", os.path.sep)
 
-    def get_session_dependencies(self, session=None):
+        # return None if the session path is empty.
+        return session_path if session_path else None
+
+    def get_session_dependencies(self):
         """
         Returns a list of file dependencies for the current session.
 
-        :param session: An object representing the active document
-                        (for MDI applications).
         :returns: A list of file dependencies required to load
                   the session. The data returned is of the form:
                   [

--- a/hooks/filter_dependencies.py
+++ b/hooks/filter_dependencies.py
@@ -1,0 +1,44 @@
+# Copyright 2017 Autodesk, Inc.  All rights reserved.
+#
+# Use of this software is subject to the terms of the Autodesk license agreement
+# provided at the time of installation or download, or which otherwise accompanies
+# this software in either electronic or hard copy form.
+#
+
+import sgtk
+
+
+class FilterDependenciesHook(sgtk.get_hook_baseclass()):
+    """
+    Hook to filter file dependencies gathered from a
+    session. Use this hook to add or remove custom file
+    dependencies for specialized requirements.
+    """
+
+    def filter_dependencies(self, dependencies):
+        """
+        Performs filtering of file dependency data and
+        returns the filtered list. It extends
+        `Engine.get_session_dependencies()` to perform any
+        post-processing on dependency data.
+
+        :param dependencies: A list of file dependencies
+                    gathered from a session. The data is
+                    of the form:
+                    [
+                     { "path": "/foo/bar/hello.%04d.jpeg",
+                       "engine": "tk-nuke",
+                       "type": "Read"
+                     },
+                     { "path": "/foo/bar/hello.%04d.obj",
+                       "engine": "tk-nuke",
+                       "type": "ReadGeo2"
+                     },
+                   ]
+        :returns: A new list containing filtered file
+                  dependency data.
+        """
+        # Generate and return a new list with modified
+        # file dependency data. For now, simply return a copy
+        # of the existing dependency list back to the caller.
+        return dependencies[:]

--- a/info.yml
+++ b/info.yml
@@ -150,7 +150,13 @@ configuration:
                         dialog for the version you are testing, it is recomended that you set this
                         value to the current major version + 1."
         default_value:  10
-    
+
+    hook_filter_dependencies:
+        type: hook
+        default_value: "{self}/filter_dependencies.py"
+        description: "This hook is responsible for filtering the default file dependencies
+                      retrieved by the engine for a particular session."
+
 # the Shotgun fields that this engine needs in order to operate correctly
 requires_shotgun_fields:
 


### PR DESCRIPTION
Added implementation for the following engine methods:
* get_session_path() - Returns the absolute file path of the nuke script if saved, else returns an empty string.
* get_session_dependencies() - Returns the file path dependencies of the current nuke script for the global file frame range. 

Linked with: https://github.com/shotgunsoftware/tk-core/pull/544