### PR TITLE
For #46098: First pass at Flame OpenClip updating when no templates exist.

### DIFF
--- a/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
+++ b/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
@@ -439,6 +439,7 @@ class UpdateFlameClipPlugin(HookBaseClass):
 
         # get a handle on the write node app, stored during accept()
         write_node_app = item.properties.get("sg_writenode_app")
+        render_path_fields = None
 
         if not write_node_app:
             # If we don't have a writenode, we just parse the first frame of the
@@ -744,8 +745,14 @@ def _generate_flame_clip_name(context, publish_fields):
 
     # if we have a channel set for the write node or a name for the scene,
     # add those
-    rp_name = publish_fields.get("name")
-    rp_channel = publish_fields.get("channel")
+    rp_name = None
+    rp_channel = None
+
+    # If we have template fields passed in, then we'll try to extract
+    # some information from them.
+    if publish_fields:
+        rp_name = publish_fields.get("name")
+        rp_channel = publish_fields.get("channel")
 
     if rp_name and rp_channel:
         name += "%s.nk (output %s), " % (rp_name, rp_channel)

--- a/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
+++ b/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
@@ -735,6 +735,11 @@ def _generate_flame_clip_name(context, publish_fields):
 
     name = ""
 
+    # If we have template fields passed in, then we'll try to extract
+    # some information from them. If we don't, then we fall back on
+    # some defaults worked out below.
+    publish_fields = publish_fields or dict()
+
     # the shot will already be implied by the clip inside Flame (the clip
     # file which we are updating is a per-shot file. But if the context
     # contains a task or a step, we can display that:
@@ -745,14 +750,8 @@ def _generate_flame_clip_name(context, publish_fields):
 
     # if we have a channel set for the write node or a name for the scene,
     # add those
-    rp_name = None
-    rp_channel = None
-
-    # If we have template fields passed in, then we'll try to extract
-    # some information from them.
-    if publish_fields:
-        rp_name = publish_fields.get("name")
-        rp_channel = publish_fields.get("channel")
+    rp_name = publish_fields.get("name")
+    rp_channel = publish_fields.get("channel")
 
     if rp_name and rp_channel:
         name += "%s.nk (output %s), " % (rp_name, rp_channel)

--- a/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
+++ b/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
@@ -302,8 +302,7 @@ class UpdateFlameClipPlugin(HookBaseClass):
             # update shot clip xml file with this publish
             self._update_flame_clip(item)
         except Exception as exc:
-            raise
-            # raise Exception("Unable to update Flame clip xml: %s" % exc)
+            raise Exception("Unable to update Flame clip xml: %s" % exc)
 
     def finalize(self, settings, item):
         """

--- a/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
+++ b/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
@@ -156,8 +156,8 @@ class UpdateFlameClipPlugin(HookBaseClass):
                 )
                 return {"accepted": False}
 
-        # Check to see if we have a template to use. In that case, the
-        # we'll be trying to find a clip file that that location. If we
+        # Check to see if we have a template to use. In that case,
+        # we'll be trying to find a clip file at that location. If we
         # don't have a template configured, or the clip file doesn't
         # exist at that location on disk, we'll look for a published
         # clip.

--- a/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
+++ b/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
@@ -219,7 +219,6 @@ class UpdateFlameClipPlugin(HookBaseClass):
 
             for clip_publish in clip_publishes:
                 self.logger.debug("Checking existence of OpenClip: %s" % clip_publish)
-                # flame_clip_path = clip_publish["path"].get("local_path")
                 try:
                     flame_clip_path = resolve_publish_path(publisher.sgtk, clip_publish)
                 except Exception:

--- a/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
+++ b/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
@@ -263,9 +263,7 @@ class UpdateFlameClipPlugin(HookBaseClass):
         else:
             self.logger.debug(
                 "Unable to look up a clip file to update. No template exists, "
-                "and the item's context is not associated with an entity. This "
-                "likely means that the we're in a Project context, which will "
-                "never contain any OpenClip publishes from Flame."
+                "and the item's context is not associated with an entity."
             )
 
         if not item.properties.get("flame_clip_path"):

--- a/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
+++ b/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
@@ -17,6 +17,7 @@ import xml.dom.minidom as minidom
 import sgtk
 
 from sgtk.util.shotgun.publish_util import get_published_file_entity_type
+from sgtk.util.shotgun.publish_resolve import resolve_publish_path
 
 
 HookBaseClass = sgtk.get_hook_baseclass()
@@ -216,13 +217,18 @@ class UpdateFlameClipPlugin(HookBaseClass):
 
             for clip_publish in clip_publishes:
                 self.logger.debug("Checking existence of OpenClip: %s" % clip_publish)
-                flame_clip_path = clip_publish["path"].get("local_path")
+                # flame_clip_path = clip_publish["path"].get("local_path")
+                try:
+                    flame_clip_path = resolve_publish_path(publisher.sgtk, clip_publish)
+                except Exception:
+                    self.logger.debug("Unable to resolve path: %s" % clip_publish)
+
                 if flame_clip_path and os.path.exists(flame_clip_path):
                     self.logger.debug("Found usable OpenClip publish: %s" % flame_clip_path)
                     break
                 else:
                     flame_clip_path = None
-                    self.logger.debug("Published OpenClip isn't accessible: %s" % clip_publish)
+                    self.logger.debug("Published OpenClip isn't accessible: %s" % flame_clip_path)
 
             if not flame_clip_path:
                 self.logger.debug("Unable to find a usable OpenClip publish.")

--- a/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
+++ b/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
@@ -200,20 +200,29 @@ class UpdateFlameClipPlugin(HookBaseClass):
             # In most cases this will not do anything differently than the template
             # driven solution, because we'll have a single OpenClip published for
             # the shot, but there might be cases where this heads off a problem.
+            clip_publish_types = ["Flame OpenClip", "Flame Batch OpenClip"]
+            self.logger.debug("Clip publish types to search for: %s" % clip_publish_types)
             clip_publishes = publisher.shotgun.find(
                 publish_type,
                 [
                     ["entity", "is", item.context.entity],
-                    ["published_file_type.PublishedFileType.code", "is", "Flame OpenClip"],
+                    ["published_file_type.PublishedFileType.code", "in", clip_publish_types],
                 ],
                 fields=("path",),
             )
+
+            if clip_publishes:
+                self.logger.debug("Found clip(s): %s" % clip_publishes)
+
             for clip_publish in clip_publishes:
                 self.logger.debug("Checking existence of OpenClip: %s" % clip_publish)
                 flame_clip_path = clip_publish["path"].get("local_path")
                 if flame_clip_path and os.path.exists(flame_clip_path):
                     self.logger.debug("Found usable OpenClip publish: %s" % flame_clip_path)
                     break
+                else:
+                    flame_clip_path = None
+                    self.logger.debug("Published OpenClip isn't accessible: %s" % clip_publish)
 
             if not flame_clip_path:
                 self.logger.debug("Unable to find a usable OpenClip publish.")

--- a/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
+++ b/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
@@ -658,8 +658,9 @@ def _get_flame_frame_spec_from_path(path):
 
     :param str path: The file path to parse.
 
-    :returns: None if no range could be determined, otherwise (min, max, frame_padding)
-    :rtype: tuple or None
+    :returns: If the path can be parsed, a string path replacing the frame
+        number with a frame range spec is returned.
+    :rtype: str or None
     """
     # This pattern will match the following at the end of a string and
     # retain the frame number or frame token as group(1) in the resulting
@@ -686,7 +687,8 @@ def _get_flame_frame_spec_from_path(path):
         return None
 
     # We need to get all files that match the pattern from disk so that we
-    # can determine what the min and max frame number is.
+    # can determine what the min and max frame number is. We replace the
+    # frame number or token with a * wildcard.
     glob_path = "%s%s" % (
         re.sub(match.group(2), "*", root),
         ext,
@@ -698,7 +700,7 @@ def _get_flame_frame_spec_from_path(path):
     file_roots = [os.path.splitext(f)[0] for f in files]
 
     # We know that the search will result in a match at this point, otherwise
-    # the glob wouldn't have found the file. We can search and pull group 1
+    # the glob wouldn't have found the file. We can search and pull group 2
     # to get the integer frame number from the file root name.
     frame_padding = len(re.search(frame_pattern, file_roots[0]).group(2))
     frames = [int(re.search(frame_pattern, f).group(2)) for f in file_roots]
@@ -711,6 +713,10 @@ def _get_flame_frame_spec_from_path(path):
         frame_padding
     )
 
+    # We end up with something like the following:
+    #
+    #    /project/foo.[0001-0010].jpg
+    #
     frame_spec = format_str % (min_frame, max_frame)
     return "%s%s%s" % (match.group(1), frame_spec, ext)
 


### PR DESCRIPTION
There are a number of behavioral changes included, as documented below.

**Input acceptance:**
* If tk-nuke-writenode is in use, only items associated with an instance of that app will be accepted.
* If the writenode app is NOT in use, then all image sequence items will be accepted.

**Clip lookup behavior:**
* If the publish plugin is configured with a "Flame Clip Template" we will attempt to find a clip file matching that template.
* If there is no template configured or the clip file does not exist in the location that the template expects it to, we look for a PublishedFile entity linked to the item's context's entity (most likely a Shot) that matches the PublishedFileType associated with Flame OpenClip publishes.

**Current caveats:**
* We're modifying a PublishedFile's file on disk in place. This is bad for philosophical and technical reasons. The solution we've discussed is creating a new PublishedFile entity at the next available version number, but pointing to the same .clip file on disk. It does not make sense to version the clip file itself, but versioning the PublishedFile entity on top of it will help keep a record of changes, and also better support potential multi-location workflows that rely of PublishedFile entities for data transfer services.
* It appears as though acceptance routines for publish plugins are not re-run when the item's link changes. This is a potential problem in a ZC situation where the user has not changed context in the Panel app prior to launching publish2. In that case, when the acceptance routine is run for the flame clip update plugin, we won't know what Shot to get a clip file from and we'll return a negative. If the user then selects their Shot/Task to publish to from the publish2 UI, we aren't re-run and we're potentially not updating a clip file when we should be. **WORKAROUND:** Set a Shot context using the Panel app prior to launching the Publish app.
* We're taking the first clip PublishedFile from the database and only modifying that one. This means that if multiple .clips are published for a given Shot, only one will be updated. This isn't a regression, as the template-based behavior has a similar caveat, but it might be worth a separate ticket to better support multiple clips if that's a workflow that makes sense for some clients.

<img width="584" alt="screen shot 2018-02-05 at 6 34 37 pm" src="https://user-images.githubusercontent.com/4913787/35839091-5df3e9b4-0aa3-11e8-8f86-898f98013001.png">

![screen shot 2018-01-29 at 5 40 16 pm](https://user-images.githubusercontent.com/4913787/35544040-2f62036e-051d-11e8-87e3-e12f411ef0df.png)

<img width="425" alt="flame_versions_clip" src="https://user-images.githubusercontent.com/4913787/35839027-2378185a-0aa3-11e8-9f71-908c226beb6c.png">