### PR TITLE
Do not attempt to regenerate menu items in no display mode

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -566,7 +566,7 @@ class NukeEngine(tank.platform.Engine):
         if not self.hiero_enabled:
             self.post_app_init_nuke()
 
-        if self._context_change_menu_rebuild:
+        if self.has_ui and self._context_change_menu_rebuild:
             self.menu_generator.create_menu()
 
     #####################################################################################


### PR DESCRIPTION
Verify that engine.has_ui is True before regenerating menu items when the context changes. 

This issue was discovered when running a Nuke script that performs context changes on a render farm.