### PR TITLE
SG-6781: Updates logic around parsing Flame openclip files during publish.

### DIFF
--- a/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
+++ b/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
@@ -553,16 +553,40 @@ class UpdateFlameClipPlugin(HookBaseClass):
         self.logger.debug("Parsing clip file: %s" % flame_clip_path)
         xml = minidom.parse(flame_clip_path)
 
-        # find first <track type="track" uid="video">
+        # We need to find the first video track. We do that by getting all of
+        # the tracks:
+        #
+        #   <track type="track" uid="video">
+        #       <trackType>video</trackType>
+        #
+        # We then look at the trackType element within, looking for a type
+        # of "video". When we find one, we break out and move on.
         first_video_track = None
+
         for track in xml.getElementsByTagName("track"):
-            if track.attributes["uid"].value == "video":
-                first_video_track = track
+            for track_type in track.getElementsByTagName("trackType"):
+                if "track" in [c.nodeValue for c in track_type.childNodes]:
+                    first_video_track = track
+                    break
+            if first_video_track is not None:
                 break
 
         if first_video_track is None:
             raise Exception(
                 "Could not find <track type='track' uid='video'> in clip file!")
+
+        clip_version = None
+        for span in xml.getElementsByTagName("spans"):
+            span_version = span.attributes.get("version")
+            if span_version is not None:
+                clip_version = span_version.value
+            if clip_version is not None:
+                break
+
+        # For backwards compatibility's sake, we default to version 4.
+        # For a long time, we just hardcoded this to 4, so it makes
+        # sense to default to it here.
+        clip_version = clip_version or "4"
 
         # now contruct our feed xml chunk we want to insert
         #
@@ -586,13 +610,13 @@ class UpdateFlameClipPlugin(HookBaseClass):
         # <spans type="spans" version="4">
         spans_node = xml.createElement("spans")
         spans_node.setAttribute("type", "spans")
-        spans_node.setAttribute("version", "4")
+        spans_node.setAttribute("version", clip_version)
         feed_node.appendChild(spans_node)
 
         # <span type="span" version="4">
         span_node = xml.createElement("span")
         span_node.setAttribute("type", "span")
-        span_node.setAttribute("version", "4")
+        span_node.setAttribute("version", clip_version)
         spans_node.appendChild(span_node)
 
         # <path encoding="pattern">%s</path>

--- a/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
+++ b/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
@@ -565,7 +565,7 @@ class UpdateFlameClipPlugin(HookBaseClass):
 
         for track in xml.getElementsByTagName("track"):
             for track_type in track.getElementsByTagName("trackType"):
-                if "track" in [c.nodeValue for c in track_type.childNodes]:
+                if "video" in [c.nodeValue for c in track_type.childNodes]:
                     first_video_track = track
                     break
             if first_video_track is not None:
@@ -573,7 +573,7 @@ class UpdateFlameClipPlugin(HookBaseClass):
 
         if first_video_track is None:
             raise Exception(
-                "Could not find <track type='track' uid='video'> in clip file!")
+                "Could not find the first video track in the published clip file!")
 
         clip_version = None
         for span in xml.getElementsByTagName("spans"):


### PR DESCRIPTION
The assumptions we made concerning the structure of the portion of a Flame openclip around video tracks were flimsy. To correct some issues we're seeing in beta and head off any future problems with the Flame<->Nuke workflow, the logic here has been tweaked to bring it in line what what the Flame engineers are expecting from our implementation.