### PR TITLE
in on_context_change() add has_ui check

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -566,7 +566,7 @@ class NukeEngine(tank.platform.Engine):
         if not self.hiero_enabled:
             self.post_app_init_nuke()
 
-        if self._context_change_menu_rebuild:
+        if self.has_ui and self._context_change_menu_rebuild:
             self.menu_generator.create_menu()
 
     #####################################################################################


### PR DESCRIPTION
Doing `engine.context_change()` while running a `nuke -t` session produces the error:
> 'NoneType' object has no attribute 'create_menu'

Checking for has_ui before attempting to create menu fixes that.