### PR TITLE
Startup optimization on registered callbacks

### DIFF
--- a/classic_startup/Python/Startup/__init__.py
+++ b/classic_startup/Python/Startup/__init__.py
@@ -61,7 +61,7 @@ def _setup_sgtk():
         return
 
     try:
-        engine = tank.platform.start_engine(engine_name, context.tank, context)
+        tank.platform.start_engine(engine_name, context.tank, context)
     except Exception, e:
         hiero.core.log.error("Shotgun: Could not start engine: %s" % str(e))
         return

--- a/classic_startup/sgtk_startup.py
+++ b/classic_startup/sgtk_startup.py
@@ -56,7 +56,7 @@ def _setup_sgtk(output_handle):
         return
 
     try:
-        engine = tank.platform.start_engine(engine_name, context.tank, context)
+        tank.platform.start_engine(engine_name, context.tank, context)
     except Exception, e:
         output_handle("Shotgun: Could not start engine: %s" % str(e))
         return

--- a/python/tk_nuke/__init__.py
+++ b/python/tk_nuke/__init__.py
@@ -18,7 +18,6 @@ QT to be imported should be placed in the tk_nuke_qt module instead
 in order to avoid import errors at startup and context switch.
 """
 import os
-import textwrap
 import nuke
 import tank
 import sys

--- a/python/tk_nuke/__init__.py
+++ b/python/tk_nuke/__init__.py
@@ -48,7 +48,7 @@ def __create_tank_disabled_menu(details):
     """
     Creates a std "disabled" shotgun menu
     """
-    if nuke.env.get("gui"):
+    if nuke.GUI:
         nuke_menu = nuke.menu("Nuke")
         sg_menu = nuke_menu.addMenu("Shotgun")
         sg_menu.clearMenu()
@@ -71,7 +71,7 @@ def __create_tank_error_menu():
     message += "Traceback (most recent call last):\n"
     message += "\n".join( traceback.format_tb(exc_traceback))
     
-    if nuke.env.get("gui"):
+    if nuke.GUI:
         nuke_menu = nuke.menu("Nuke")
         sg_menu = nuke_menu.addMenu("Shotgun")
         sg_menu.clearMenu()

--- a/python/tk_nuke/__init__.py
+++ b/python/tk_nuke/__init__.py
@@ -79,12 +79,14 @@ def __create_tank_error_menu():
         sg_menu.addCommand("[Shotgun Error - Click for details]", cmd)
     else:
         nuke.error("The Shotgun Pipeline Toolkit caught an error: %s" % message)
-    
-def __engine_refresh(tk, new_context):
+
+
+def __engine_refresh(new_context):
     """
     Change the current engine context if the engine is up.
     Otherwise start the engine with the given context
     """
+    tk = new_context.tank
     curr_engine = tank.platform.current_engine()
 
     if curr_engine:
@@ -144,7 +146,7 @@ def __tank_on_save_callback():
         new_ctx = tk.context_from_path(file_name, curr_ctx)
         
         # now restart the engine with the new context
-        __engine_refresh(tk, new_ctx)
+        __engine_refresh(new_ctx)
     except Exception, e:
         __create_tank_error_menu()
 
@@ -191,7 +193,7 @@ def tank_startup_node_callback():
             new_ctx = tk.context_from_path(file_name, curr_ctx)
     
         # now restart the engine with the new context
-        __engine_refresh(tk, new_ctx)
+        __engine_refresh(new_ctx)
     except Exception, e:
         __create_tank_error_menu()
         

--- a/python/tk_nuke_qt/panels.py
+++ b/python/tk_nuke_qt/panels.py
@@ -12,8 +12,6 @@
 Panel support for Nuke
 """
 
-import os
-import sys
 import nuke
 import sgtk
 import nukescripts


### PR DESCRIPTION
To speed up the startup, I made the following updates on registered callbacks:

If a current engine is running
1. Avoid to create a tank object
1. engine_refresh: try to change_context with the new context instead of starting a new engine each time