### PR TITLE
SG-11232 Small bug fix for error menu generation in Nuke Studio

### DIFF
--- a/python/tk_nuke/context.py
+++ b/python/tk_nuke/context.py
@@ -279,8 +279,8 @@ class ClassicStudioContextSwitcher(object):
 
             # Now change the context for the engine and apps.
             self.change_context(new_ctx)
-        except Exception, e:
-            self.engine.menu_generator.create_sgtk_error_menu(e)
+        except Exception:
+            self.engine.menu_generator.create_sgtk_error_menu()
 
     ##########################################################################
     # public

--- a/python/tk_nuke/menu_generation.py
+++ b/python/tk_nuke/menu_generation.py
@@ -15,6 +15,7 @@ import sys
 import nuke
 import os
 import unicodedata
+import traceback
 import nukescripts.openurl
 import nukescripts
 


### PR DESCRIPTION
A small bug fix for an issue where it errored trying to display the error menu in Nuke Studio.
![image001](https://user-images.githubusercontent.com/3777228/53963989-4d986700-40e6-11e9-8ea9-211de5829680.png)
