### PR TITLE
SG-14088 makes sgkt_on_load_callback public

### DIFF
--- a/python/tk_nuke/__init__.py
+++ b/python/tk_nuke/__init__.py
@@ -158,7 +158,7 @@ def __sgtk_on_save_callback():
         __create_tank_error_menu()
 
 
-def __sgtk_on_load_callback():
+def sgtk_on_load_callback():
     """
     Callback that fires every time a script is loaded.
 

--- a/python/tk_nuke/__init__.py
+++ b/python/tk_nuke/__init__.py
@@ -241,7 +241,7 @@ def tank_ensure_callbacks_registered(engine=None):
     if not engine or engine.get_setting("automatic_context_switch"):
         global g_tank_callbacks_registered
         if not g_tank_callbacks_registered:
-            nuke.addOnScriptLoad(__sgtk_on_load_callback)
+            nuke.addOnScriptLoad(sgtk_on_load_callback)
             nuke.addOnScriptSave(__sgtk_on_save_callback)
             g_tank_callbacks_registered = True
     elif engine and not engine.get_setting("automatic_context_switch"):
@@ -249,7 +249,7 @@ def tank_ensure_callbacks_registered(engine=None):
         # are removed.
         global g_tank_callbacks_registered
         if g_tank_callbacks_registered:
-            nuke.removeOnScriptLoad(__sgtk_on_load_callback)
+            nuke.removeOnScriptLoad(sgtk_on_load_callback)
             nuke.removeOnScriptSave(__sgtk_on_save_callback)
             g_tank_callbacks_registered = False
 


### PR DESCRIPTION
Reverses a change in v0.12.1 to make the `sgtk_on_load_callback` public again, as it is called from out side the module.

https://github.com/shotgunsoftware/tk-nuke/blob/v0.12.2/plugins/basic/Python/tk_nuke_basic/plugin_bootstrap.py#L334
