### PR TITLE
SG-14409: Cleans up sys.path responsibly after bootstrapping

### DIFF
--- a/classic_startup/init.py
+++ b/classic_startup/init.py
@@ -21,9 +21,13 @@ if not os.environ.get("SHOTGUN_INIT_RUN"):
     os.environ["SHOTGUN_INIT_RUN"] = "1"
 
     if not nuke.GUI:
-        sys.path.append(os.path.dirname(__file__))
+        startup_path = os.path.dirname(__file__)
+        sys.path.append(startup_path)
         try:
             # importing sgtk_startup is enough to trigger the bootstrap process
             import sgtk_startup
         finally:
-            sys.path.pop()
+            # We can't just pop sys.path, because the sgtk_startup routine
+            # might have run some code during bootstrap that appended to
+            # sys.path.
+            sys.path = [p for p in sys.path if p != startup_path]

--- a/classic_startup/menu.py
+++ b/classic_startup/menu.py
@@ -11,10 +11,14 @@
 import os
 import sys
 
-sys.path.append(os.path.dirname(__file__))
+startup_path = os.path.dirname(__file__)
+sys.path.append(startup_path)
 
 # This covers initialization of Toolkit in GUI sessions of Nuke.
 try:
     import sgtk_startup # noqa
 finally:
-    sys.path.pop()
+    # We can't just pop sys.path, because the sgtk_startup routine
+    # might have run some code during bootstrap that appended to
+    # sys.path.
+    sys.path = [p for p in sys.path if p != startup_path]

--- a/engine.py
+++ b/engine.py
@@ -152,9 +152,6 @@ class NukeEngine(tank.platform.Engine):
 
         self.logger.debug("%s: Initializing...", self)
 
-        local_python_path = os.path.abspath(os.path.join(self.disk_location, "python"))
-        # append the local path so that the tk_nuke and tk_nuke_qt packages can be imported
-        sys.path.append(local_python_path)
         import tk_nuke
         tk_nuke.tank_ensure_callbacks_registered(engine=self)
 


### PR DESCRIPTION
We were popping off of sys.path after bootstrapping, which meant we removed the last thing appended to sys.path that might have occurred during engine init instead of what we intended to clean up. We now filter out the specific path we added prior to bootstrapping instead.