### PR TITLE
SG-14164: Resolves shotgunpanel crashing in Nuke 12.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -175,7 +175,7 @@ class NukeEngine(tank.platform.Engine):
             return
 
         # Versions > 10.5 have not yet been tested so show a message to that effect.
-        if nuke_version[0] > 11 or (nuke_version[0] == 11 and nuke_version[1] > 3):
+        if nuke_version[0] > 12 or (nuke_version[0] == 12 and nuke_version[1] > 0):
             # This is an untested version of Nuke.
             msg = ("The Shotgun Pipeline Toolkit has not yet been fully tested with Nuke %d.%dv%d. "
                    "You can continue to use the Toolkit but you may experience bugs or "

--- a/python/tk_nuke_qt/panels.py
+++ b/python/tk_nuke_qt/panels.py
@@ -212,8 +212,25 @@ class ToolkitWidgetWrapper(QtGui.QWidget):
             bundle.logger.debug("Created new toolkit panel widget %s", self.toolkit_widget)
             
             # now let the core apply any external stylesheets
-            bundle.engine._apply_external_styleshet(bundle, self.toolkit_widget)
-            
+            #
+            # NOTE: To be honest, we're not entirely sure why this is required. In Nuke 12
+            # we started experiencing a crash when the shotgunpanel app was being launched
+            # in panel mode. On OSX that was cured with a tiny tweak to the qss itself, but
+            # the problem persisted on Windows and Linux. In those cases, it does not appear
+            # that anything in the qss itself was the problem, it was simply that there was
+            # qss being applied AT ALL right here.
+            #
+            # The solution here is to defer the application of the stylesheet by 1ms, which
+            # gives Qt time process other events before getting to this call. With that in
+            # mind, we did attempt to just make a call to processEvents here to try to get
+            # the same result without a timer, but that did not stop the crash problem.
+            def _set_qss():
+                bundle.engine._apply_external_styleshet(bundle, self.toolkit_widget)
+
+            self._timer = QtCore.QTimer(self.toolkit_widget)
+            self._timer.setSingleShot(True)
+            self._timer.timeout.connect(_set_qss)
+            self._timer.start(1)
         else:
             # there is already a dialog. Re-parent it to this
             # object and move it across into this layout

--- a/python/tk_nuke_qt/panels.py
+++ b/python/tk_nuke_qt/panels.py
@@ -230,7 +230,7 @@ class ToolkitWidgetWrapper(QtGui.QWidget):
             self._timer = QtCore.QTimer(self.toolkit_widget)
             self._timer.setSingleShot(True)
             self._timer.timeout.connect(_set_qss)
-            self._timer.start(1)
+            self._timer.start(0)
         else:
             # there is already a dialog. Re-parent it to this
             # object and move it across into this layout


### PR DESCRIPTION
A small qss tweak in the shotgunpanel app resolved the crashing problems on OSX, but the issue persisted despite that on Windows and Linux. That crash in Nuke 12 does not appear to be tied to the qss itself, but the fact that ANY qss is being applied at the exact moment that it is in our panel-specific logic in tk-nuke.

This fix works and has no visible impact for the user. We're just deferring the application of the qss until Qt has a chance to finish whatever it's doing at that moment.