### PR TITLE
Update startup.py

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -49,6 +49,7 @@ class NukeLauncher(SoftwareLauncher):
         "NukeAssist",
         "NukeStudio",
         "NukeX",
+        "Hiero",
     ]
 
     # This dictionary defines a list of executable template strings for each


### PR DESCRIPTION
This allows Hiero to be loaded just like NukeStudio
- Adding Hiero to the NUKE_9_OR_HIGHER_PRODUCTS in this startup.py
- Removing hiero references from the config here: `https://github.com/shotgunsoftware/tk-config-default2/blob/master/env/includes/software_paths.yml`
- adding the following lines into the `determine_engine_instance_name` function in here: `https://github.com/shotgunsoftware/tk-config-default2/blob/master/hooks/tk-multi-launchapp/before_register_command.py`

`if software_version.product == "Hiero":`
`    engine_instance_name = "tk-hiero"`