### PR TITLE
Handle Hiero API deprecated projectRoot methods

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -764,8 +764,8 @@ class NukeEngine(tank.platform.Engine):
         """
         import hiero
 
-        # The nested methods below are wrapper functions that call the appropriate hiero project_root
-        # functions according to the nuke version. Some methods are deprecated in Nuke 12.
+        # Since some Hiero projectRoot methods are deprecated in Nuke 12, we use the wrapper methods
+        # below to call the appropriate Hiero methods according to the Nuke version being used.
         # Cf. https://learn.foundry.com/hiero/developers/12.0/hieropythondevguide/api/api_core.html
         
         # Project.projectRoot() will be removed in Nuke 12

--- a/engine.py
+++ b/engine.py
@@ -764,12 +764,29 @@ class NukeEngine(tank.platform.Engine):
         """
         import hiero
 
+        # The nested methods below are wrapper functions that call the appropriate hiero project_root
+        # functions according to the nuke version. Some methods are deprecated in Nuke 12.
+        # Cf. https://learn.foundry.com/hiero/developers/12.0/hieropythondevguide/api/api_core.html
+        
+        # Project.projectRoot() will be removed in Nuke 12
+        def project_root_wrapper(p):
+            if nuke.env.get("NukeVersionMajor") < 12:
+                return p.projectRoot()
+            return p.exportRootDirectory()
+
+        # Project.setProjectRoot() will be removed in Nuke 12
+        def set_project_root_wrapper(p, tank_project_path):
+            if nuke.env.get("NukeVersionMajor") < 12:
+                p.setProjectRoot(tank_project_path)
+            else:
+                p.setProjectDirectory(tank_project_path)
+
         for p in hiero.core.projects():
-            if not p.projectRoot():
+            if not project_root_wrapper(p):
                 self.logger.debug(
                     "Setting projectRoot on %s to: %s", p.name(), self.tank.project_path
                 )
-                p.setProjectRoot(self.tank.project_path)
+                set_project_root_wrapper(p, self.tank.project_path)
 
     def _get_dialog_parent(self):
         """


### PR DESCRIPTION
In Nuke 12, some methods of the API `hiero.core` are deprecated and will be removed. That's the case for `Project.projectRoot()` and `Project.setProjectRoot()`

This Pull Request proposes to handle these cases with wrapper methods that will call the API method recommended by Hiero 
Documentation when the Nuke version being used is superior or equal to 12.

https://learn.foundry.com/hiero/developers/12.0/hieropythondevguide/api/api_core.html