### PR TITLE
SG-18819 Fix for locking up of Nuke when logging.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -177,7 +177,7 @@ class NukeEngine(tank.platform.Engine):
             return
 
         # Versions > 10.5 have not yet been tested so show a message to that effect.
-        if nuke_version[0] > 12 or (nuke_version[0] == 12 and nuke_version[1] > 1):
+        if nuke_version[0] > 12 or (nuke_version[0] == 12 and nuke_version[1] > 2):
             # This is an untested version of Nuke.
             msg = (
                 "The Shotgun Pipeline Toolkit has not yet been fully tested with Nuke %d.%dv%d. "

--- a/engine.py
+++ b/engine.py
@@ -619,7 +619,7 @@ class NukeEngine(tank.platform.Engine):
                 nuke.warning("Shotgun Warning: %s" % msg)
 
         # Sends the message to the script editor.
-        print(msg)
+        self.async_execute_in_main_thread(print, msg)
 
     #####################################################################################
     # Panel Support


### PR DESCRIPTION
Fix for Nuke hanging when an app produces a lot of output and the script editor is open.