### PR TITLE
SG-19954: Fixes a freeze when launching Nuke v11.3 with debugging logging on.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -619,7 +619,12 @@ class NukeEngine(tank.platform.Engine):
                 nuke.warning("Shotgun Warning: %s" % msg)
 
         # Sends the message to the script editor.
-        self.async_execute_in_main_thread(print, msg)
+        # Originally, this line passed print and msg in directly.
+        # and it locked up Nuke v11.3 when it happened. There's probably
+        # some weird issue when passing a CPython function instead of
+        # a pure Python method to a Qt signal, so wrap the call into a
+        # lambda to make the issue go away.
+        self.async_execute_in_main_thread(lambda: print(msg))
 
     #####################################################################################
     # Panel Support

--- a/engine.py
+++ b/engine.py
@@ -534,8 +534,9 @@ class NukeEngine(tank.platform.Engine):
         # it is causing a deadlock whenever an app calls
         # engine.async_execute_in_main_thread from a background thread.
         # The theory is that the main thread is locked up by Nuke in a
-        # way that prevents Toolkit to queue new events. For whatever reason
-        # using a QTimer will work here.
+        # way that prevents Toolkit to queue new events. Instead, we'll queue
+        # the launch of the apps until the main thread has finished executing
+        # current events.
         tank.platform.qt.QtCore.QTimer.singleShot(0, run_at_startup)
 
     def destroy_engine(self):

--- a/engine.py
+++ b/engine.py
@@ -523,7 +523,7 @@ class NukeEngine(tank.platform.Engine):
 
         def run_at_startup():
             # FIXME: This pattern is horrible.
-            setattr(tank, "_callback_from_non_pane_menu", True)
+            tank._callback_from_non_pane_menu = True
             try:
                 for command in commands_to_run:
                     print(command)

--- a/engine.py
+++ b/engine.py
@@ -526,7 +526,6 @@ class NukeEngine(tank.platform.Engine):
             tank._callback_from_non_pane_menu = True
             try:
                 for command in commands_to_run:
-                    print(command)
                     command()
             finally:
                 delattr(tank, "_callback_from_non_pane_menu")


### PR DESCRIPTION
NEW FIX DESCRIPTION: The run_at_startup commands are executed while the splashscreen is visited, which is when nuke informs us that the GUI is ready. Unfortunately, it appears that calling async_execute_to_main_thread will lock up at that point of the startup process. I've tried reimplementing it in tk-core with `QMetaObject`, just like  `execute_from_main_thread`, but it still locked up. This is unexpected as a `Qt.QueueConnection` is expected to be non-blocking. What I suspect is happening here is that the main thread has a lock the list of events in the main thread and is not relinquishing it for some reason and our background thread is stuck waiting for the main thread to relinquish it so it can send it's signal.

In the end, I ended up doing something else: postponing the launch of startup commands until after the main thread is done executing events by using `QTimer.singleShot`.

ORIGINAL FIX DESCRIPTION: Originally, we passed print and msg in directly and it locked up Nuke v11.3 when it happened. There's probably some weird issue when passing a CPython function instead of a pure Python method to a Qt signal, so wrap the call into a lambda to make the issue go away.