### PR TITLE
updated requires core version

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -162,4 +162,4 @@ description: "Shotgun Integration in Nuke"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "NEEDS TO BE UPDATED"
+requires_core_version: "v0.19.18"


### PR DESCRIPTION
It seems we forgot to update the requires core version when we did the work to replace support email by support url