### PR TITLE
SG-25108 Fix Python 3.9 Azure Pipelines Tests for tk-nuke

### DIFF
--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -12,7 +12,6 @@ from __future__ import with_statement
 from __future__ import print_function
 import os
 import sys
-import six
 
 from tank_test.tank_test_base import TankTestBase
 from tank_test.tank_test_base import setUpModule  # noqa

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -258,11 +258,11 @@ class TestStartup(TankTestBase):
             # In Python 3 glob doesn't use os.listdir to help iterate over the folders
             # It uses it's own _iterdir method, which still produces the same output.
 
-            if sys.version_info[0:2] >= (3, 9):  # six.PY3:
+            if sys.version_info[0:2] >= (3, 9):
                 with mock.patch("glob._iterdir", wraps=self._glob_wrapper39):
                     yield
 
-            elif sys.version_info[0:2] >= (3, 7):
+            elif six.PY3:
                 with mock.patch("glob._iterdir", wraps=self._glob_wrapper):
                     yield
 

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -262,7 +262,7 @@ class TestStartup(TankTestBase):
                 with mock.patch("glob._iterdir", wraps=self._glob_wrapper):
                     yield
 
-            if sys.version_info[0:2] >= (3, 9):  # six.PY3:
+            elif sys.version_info[0:2] >= (3, 9):  # six.PY3:
                 with mock.patch("glob._iterdir", wraps=self._glob_wrapper39):
                     yield
             else:

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -173,13 +173,12 @@ class TestStartup(TankTestBase):
         # on the items to get all the names.
         return current_depth_gen
 
-
     def _glob_wrapper(self, directory, dironly):
         """
         This is a mocked implementation of glob._iterdir.
         This method fakes a folder hierarchy.
         """
-                
+
         tokens = self._recursive_split(directory)
         # Start at the root of the mocked file system
         current_depth = self._get_os_neutral_hierarchy()
@@ -195,7 +194,6 @@ class TestStartup(TankTestBase):
         # We're using dicts for intermediary folders and lists for leaf folders so iterate
         # on the items to get all the names.
         return iter(current_depth)
-
 
     def _os_listdir_wrapper(self, directory):
         """
@@ -264,7 +262,7 @@ class TestStartup(TankTestBase):
                 with mock.patch("glob._iterdir", wraps=self._glob_wrapper):
                     yield
 
-            if sys.version_info[0:2] >= (3, 9):#six.PY3:
+            if sys.version_info[0:2] >= (3, 9):  # six.PY3:
                 with mock.patch("glob._iterdir", wraps=self._glob_wrapper39):
                     yield
             else:
@@ -496,12 +494,6 @@ class TestStartup(TankTestBase):
 
         with self._mock_folder_listing():
             # Ensure we are getting back the right variations.
-            # import sys
-            # sys.path.append(
-            #     r"/Applications/PyCharm.app/Contents/debug-eggs/pydevd-pycharm.egg")
-            # import pydevd
-            # pydevd.settrace('localhost', port=5490, stdoutToServer=True,
-            #                 stderrToServer=True)
             software_versions = self._nuke_launcher.scan_software()
 
         expected_variations = set(expected_variations)

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -258,13 +258,14 @@ class TestStartup(TankTestBase):
             # In Python 3 glob doesn't use os.listdir to help iterate over the folders
             # It uses it's own _iterdir method, which still produces the same output.
 
-            if sys.version_info[0:2] == (3, 7):
+            if sys.version_info[0:2] >= (3, 9):  # six.PY3:
+                with mock.patch("glob._iterdir", wraps=self._glob_wrapper39):
+                    yield
+
+            elif sys.version_info[0:2] >= (3, 7):
                 with mock.patch("glob._iterdir", wraps=self._glob_wrapper):
                     yield
 
-            elif sys.version_info[0:2] >= (3, 9):  # six.PY3:
-                with mock.patch("glob._iterdir", wraps=self._glob_wrapper39):
-                    yield
             else:
                 with mock.patch("os.listdir", wraps=self._os_listdir_wrapper):
                     yield


### PR DESCRIPTION
This PR fixes the Python 3.9 tests in Azure, using a new mocked implementation of glob._iterdir() method for Python >=3.9.