### PR TITLE
Include Hiero as a software option

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -48,6 +48,7 @@ class NukeLauncher(SoftwareLauncher):
         "NukeAssist",
         "NukeStudio",
         "NukeX",
+        "Hiero",
     ]
 
     # This dictionary defines a list of executable template strings for each


### PR DESCRIPTION
For some reason Hiero was forgotten from the Nuke 9 or higher software list.

There is good value in being able to support Hiero launching instead of just Nuke and Studio.

This should be an easy patch but let me know if you have any questions