### PR TITLE
SG-20925 Formalize the deprecation of python 2.6 support in toolkit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python 2.6 2.7 3.7](https://img.shields.io/badge/python-2.6%20%7C%202.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
 [![Build Status](https://secure.travis-ci.org/shotgunsoftware/tk-nuke.png?branch=master)](http://travis-ci.org/shotgunsoftware/tk-nuke)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-nuke?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=83&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/engine.py
+++ b/engine.py
@@ -297,11 +297,13 @@ class NukeEngine(sgtk.platform.Engine):
                 self._context_switcher = tk_nuke.PluginStudioContextSwitcher(self)
             else:
                 hiero.core.events.registerInterest(
-                    "kAfterNewProjectCreated", self.set_project_root,
+                    "kAfterNewProjectCreated",
+                    self.set_project_root,
                 )
 
                 hiero.core.events.registerInterest(
-                    "kAfterProjectLoad", self._on_project_load_callback,
+                    "kAfterProjectLoad",
+                    self._on_project_load_callback,
                 )
 
                 self._context_switcher = tk_nuke.ClassicStudioContextSwitcher(self)
@@ -310,7 +312,8 @@ class NukeEngine(sgtk.platform.Engine):
                 # processed. This ensure that all Nuke gizmos for the target environment
                 # will be available.
                 hiero.core.events.registerInterest(
-                    "kSelectionChanged", self._handle_studio_selection_change,
+                    "kSelectionChanged",
+                    self._handle_studio_selection_change,
                 )
 
     def log_user_attribute_metric(self, name, value):
@@ -337,11 +340,13 @@ class NukeEngine(sgtk.platform.Engine):
             self._menu_generator.create_menu()
 
             hiero.core.events.registerInterest(
-                "kAfterNewProjectCreated", self.set_project_root,
+                "kAfterNewProjectCreated",
+                self.set_project_root,
             )
 
             hiero.core.events.registerInterest(
-                "kAfterProjectLoad", self._on_project_load_callback,
+                "kAfterProjectLoad",
+                self._on_project_load_callback,
             )
 
     def post_app_init_nuke(self, menu_name="ShotGrid"):
@@ -377,7 +382,8 @@ class NukeEngine(sgtk.platform.Engine):
             # the one it needs and then run the callback.
             for (panel_id, panel_dict) in self.panels.items():
                 nukescripts.panels.registerPanel(
-                    panel_id, panel_dict["callback"],
+                    panel_id,
+                    panel_dict["callback"],
                 )
 
         # Iterate over all apps, if there is a gizmo folder, add it to nuke path.
@@ -555,15 +561,18 @@ class NukeEngine(sgtk.platform.Engine):
             import hiero.core
 
             hiero.core.events.unregisterInterest(
-                "kAfterNewProjectCreated", self.set_project_root,
+                "kAfterNewProjectCreated",
+                self.set_project_root,
             )
             hiero.core.events.unregisterInterest(
-                "kAfterProjectLoad", self._on_project_load_callback,
+                "kAfterProjectLoad",
+                self._on_project_load_callback,
             )
 
             if self.studio_enabled:
                 hiero.core.events.unregisterInterest(
-                    "kSelectionChanged", self._handle_studio_selection_change,
+                    "kSelectionChanged",
+                    self._handle_studio_selection_change,
                 )
 
     def post_context_change(self, old_context, new_context):
@@ -897,7 +906,8 @@ class NukeEngine(sgtk.platform.Engine):
             # Extract a new context based on the file and change to that
             # context.
             new_context = tk.context_from_path(
-                script_path, previous_context=self.context,
+                script_path,
+                previous_context=self.context,
             )
 
             if new_context != self.context:

--- a/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
+++ b/hooks/tk-multi-publish2/basic/nuke_update_flame_clip.py
@@ -638,7 +638,10 @@ class UpdateFlameClipPlugin(HookBaseClass):
         #     </userData>
         # </version>
         date_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        formatted_name = _generate_flame_clip_name(item, render_path_fields,)
+        formatted_name = _generate_flame_clip_name(
+            item,
+            render_path_fields,
+        )
 
         # <version type="version" uid="%s">
         version_node = xml.createElement("version")
@@ -775,7 +778,10 @@ def _get_flame_frame_spec_from_path(path):
     # We need to get all files that match the pattern from disk so that we
     # can determine what the min and max frame number is. We replace the
     # frame number or token with a * wildcard.
-    glob_path = "%s%s" % (re.sub(match.group(2), "*", root), ext,)
+    glob_path = "%s%s" % (
+        re.sub(match.group(2), "*", root),
+        ext,
+    )
     files = glob.glob(glob_path)
 
     # Our pattern from above matches against the file root, so we need
@@ -850,7 +856,10 @@ def _generate_flame_clip_name(item, publish_fields):
     # foo1234  -> foo
     # foo_1234 -> foo
     default_name = re.sub(r"[._]*\d+$", "", default_name)
-    rp_name = publish_fields.get("name", default_name,)
+    rp_name = publish_fields.get(
+        "name",
+        default_name,
+    )
     rp_channel = publish_fields.get("channel")
 
     if rp_name and rp_channel:

--- a/python/tk_nuke/context.py
+++ b/python/tk_nuke/context.py
@@ -189,7 +189,10 @@ class ClassicStudioContextSwitcher(object):
         """
         tk = tank.tank_from_path(script)
 
-        context = tk.context_from_path(script, previous_context=self.engine.context,)
+        context = tk.context_from_path(
+            script,
+            previous_context=self.engine.context,
+        )
 
         if context.project is None:
             raise tank.TankError(
@@ -233,7 +236,8 @@ class ClassicStudioContextSwitcher(object):
             # Extract a new context based on the file and change to that
             # context.
             new_context = tk.context_from_path(
-                file_name, previous_context=self.context,
+                file_name,
+                previous_context=self.context,
             )
 
             self.change_context(new_context)
@@ -270,7 +274,8 @@ class ClassicStudioContextSwitcher(object):
                     return
 
                 new_ctx = tk.context_from_path(
-                    file_name, previous_context=self.context,
+                    file_name,
+                    previous_context=self.context,
                 )
 
             # Now change the context for the engine and apps.
@@ -346,7 +351,8 @@ class ClassicStudioContextSwitcher(object):
 
         # Event for context switching from Hiero to Nuke.
         hiero.core.events.registerInterest(
-            hiero.core.events.EventType.kContextChanged, self._eventHandler,
+            hiero.core.events.EventType.kContextChanged,
+            self._eventHandler,
         )
 
         for func_desc in self._event_desc:
@@ -381,7 +387,8 @@ class ClassicStudioContextSwitcher(object):
         import hiero.core
 
         hiero.core.events.unregisterInterest(
-            hiero.core.events.EventType.kContextChanged, self._eventHandler,
+            hiero.core.events.EventType.kContextChanged,
+            self._eventHandler,
         )
 
         func_descs = only or self._event_desc

--- a/python/tk_nuke/menu_generation.py
+++ b/python/tk_nuke/menu_generation.py
@@ -41,10 +41,18 @@ class BaseMenuGenerator(object):
 
         engine_root_dir = self.engine.disk_location
         self._shotgun_logo = os.path.abspath(
-            os.path.join(engine_root_dir, "resources", "sg_logo_80px.png",),
+            os.path.join(
+                engine_root_dir,
+                "resources",
+                "sg_logo_80px.png",
+            ),
         )
         self._shotgun_logo_blue = os.path.abspath(
-            os.path.join(engine_root_dir, "resources", "sg_logo_blue_32px.png",),
+            os.path.join(
+                engine_root_dir,
+                "resources",
+                "sg_logo_blue_32px.png",
+            ),
         )
 
     @property
@@ -250,16 +258,19 @@ class HieroMenuGenerator(BaseMenuGenerator):
 
         # Register for the interesting events.
         hiero.core.events.registerInterest(
-            "kShowContextMenu/kBin", self.eventHandler,
+            "kShowContextMenu/kBin",
+            self.eventHandler,
         )
         hiero.core.events.registerInterest(
-            "kShowContextMenu/kTimeline", self.eventHandler,
+            "kShowContextMenu/kTimeline",
+            self.eventHandler,
         )
         # Note that the kViewer works differently than the other things
         # (returns a hiero.ui.Viewer object: http://docs.thefoundry.co.uk/hiero/10/hieropythondevguide/api/api_ui.html#hiero.ui.Viewer)
         # so we cannot support this easily using the same principles as for the other things.
         hiero.core.events.registerInterest(
-            "kShowContextMenu/kSpreadsheet", self.eventHandler,
+            "kShowContextMenu/kSpreadsheet",
+            self.eventHandler,
         )
         self._menu_handle.addSeparator()
 
@@ -309,16 +320,19 @@ class HieroMenuGenerator(BaseMenuGenerator):
 
         # Register for the interesting events.
         hiero.core.events.unregisterInterest(
-            "kShowContextMenu/kBin", self.eventHandler,
+            "kShowContextMenu/kBin",
+            self.eventHandler,
         )
         hiero.core.events.unregisterInterest(
-            "kShowContextMenu/kTimeline", self.eventHandler,
+            "kShowContextMenu/kTimeline",
+            self.eventHandler,
         )
         # Note that the kViewer works differently than the other things
         # (returns a hiero.ui.Viewer object: http://docs.thefoundry.co.uk/hiero/10/hieropythondevguide/api/api_ui.html#hiero.ui.Viewer)
         # so we cannot support this easily using the same principles as for the other things.
         hiero.core.events.unregisterInterest(
-            "kShowContextMenu/kSpreadsheet", self.eventHandler,
+            "kShowContextMenu/kSpreadsheet",
+            self.eventHandler,
         )
 
     def eventHandler(self, event):
@@ -492,7 +506,9 @@ class NukeStudioMenuGenerator(HieroMenuGenerator):
 
         callback = lambda m=msg: nuke.message(m)
         cmd = HieroAppCommand(
-            self.engine, cmd_name, dict(properties=dict(), callback=callback),
+            self.engine,
+            cmd_name,
+            dict(properties=dict(), callback=callback),
         )
         cmd.add_command_to_menu(self._menu_handle, icon=self._shotgun_logo_blue)
 
@@ -601,7 +617,8 @@ class NukeMenuGenerator(BaseMenuGenerator):
             if cmd.type == "panel":
                 # First make sure the Shotgun pane menu exists.
                 pane_menu = nuke.menu("Pane").addMenu(
-                    "ShotGrid", icon=self._shotgun_logo,
+                    "ShotGrid",
+                    icon=self._shotgun_logo,
                 )
                 # Now set up the callback.
                 cmd.add_command_to_pane_menu(pane_menu)
@@ -623,7 +640,9 @@ class NukeMenuGenerator(BaseMenuGenerator):
 
         callback = lambda m=msg: nuke.message(m)
         cmd = NukeAppCommand(
-            self.engine, cmd_name, dict(properties=dict(), callback=callback),
+            self.engine,
+            cmd_name,
+            dict(properties=dict(), callback=callback),
         )
         cmd.add_command_to_menu(self._menu_handle, icon=self._shotgun_logo_blue)
 

--- a/python/tk_nuke_qt/panels.py
+++ b/python/tk_nuke_qt/panels.py
@@ -51,7 +51,12 @@ class NukePanelWidget(nukescripts.panels.PythonPanel):
         # we cannot pass parameters to the constructor of our wrapper class
         # directly, so instead pass them via a special class method
         ToolkitWidgetWrapper.set_init_parameters(
-            widget_class, panel_id, bundle, self, args, kwargs,
+            widget_class,
+            panel_id,
+            bundle,
+            self,
+            args,
+            kwargs,
         )
 
         # Run parent constructor

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -286,7 +286,8 @@ class TestStartup(TankTestBase):
             return cls._mac_mock_hierarchy
 
     def _get_plugin_environment(
-        self, dcc_path,
+        self,
+        dcc_path,
     ):
         """
         Returns the expected environment variables dictionary for a plugin.


### PR DESCRIPTION
This PR includes the actions to remove Python 2.6 support in toolkit:
        - Remove python 2.6 badges
        - Update setup.py to drop support for 2.6
        - Update the documentation and the developer.shotgunsoftware.com doc site