### PR TITLE
Add setting for keeping Project context if couldn't resolve sgtk from path (SG-30710)

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -19,6 +19,12 @@ configuration:
                      context every time the currently loaded file changes. Defaults to True."
         default_value: True
 
+    allow_keep_context_from_project:
+        type: bool
+        description: "Controls whether Toolkit should try to keep project context when it
+                     fails to switch context automatically based on file location. Defaults to False."
+        default_value: False
+
     launch_builtin_plugins:
         type: list
         description: Comma-separated list of tk-nuke plugins to load when launching Nuke. Use

--- a/python/tk_nuke/__init__.py
+++ b/python/tk_nuke/__init__.py
@@ -195,6 +195,14 @@ def sgtk_on_load_callback():
                 logger.debug("Instance '%s'is associated with '%s'" % (tk, file_name))
             except sgtk.TankError as e:
                 logger.debug("No tk instance associated with '%s': %s" % (file_name, e))
+                if engine.get_setting("allow_keep_context_from_project"):
+                    cur_project = engine.context.project
+                    if cur_project:
+                        logger.debug("Trying to create context from Project '%s'" % (cur_project["name"]))
+                        tk = sgtk.sgtk_from_entity("Project", cur_project["id"])
+                        proj_ctx = tk.context_from_entity("Project", cur_project["id"])
+                        __engine_refresh(proj_ctx)
+                        return
                 __create_tank_disabled_menu(e)
                 return
 


### PR DESCRIPTION
Currently, if someone opens a file with Nuke's File --> Open, that does not reside in any known project path, the project context is lost and the ShotGrid menu is disabled.

This pull request adds an engine setting that allows for keeping at least the project context enabled so that the user can use the shotgrid workfiles app to save the current file into the pipeline.
There are various workflows where this is preferable over simply disabling toolkit.