### PR TITLE
SG-30710 Add Setting For Keeping Project Context if Couldn’t Resolve sgtk From Path

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -19,6 +19,12 @@ configuration:
                      context every time the currently loaded file changes. Defaults to True."
         default_value: True
 
+    allow_keep_context_from_project:
+        type: bool
+        description: "Controls whether Toolkit should try to keep project context when it
+                     fails to switch context automatically based on file location. Defaults to False."
+        default_value: False
+
     launch_builtin_plugins:
         type: list
         description: Comma-separated list of tk-nuke plugins to load when launching Nuke. Use

--- a/python/tk_nuke/__init__.py
+++ b/python/tk_nuke/__init__.py
@@ -195,6 +195,17 @@ def sgtk_on_load_callback():
                 logger.debug("Instance '%s'is associated with '%s'" % (tk, file_name))
             except sgtk.TankError as e:
                 logger.debug("No tk instance associated with '%s': %s" % (file_name, e))
+                # The current file does not belong to any known Toolkit project,
+                # check if the 'allow_keep_context_from_project' engine setting is
+                # enabled to see if we should keep the Project context
+                if engine.get_setting("allow_keep_context_from_project"):
+                    cur_project = engine.context.project
+                    if cur_project:
+                        logger.debug("Trying to create context from Project '%s'" % (cur_project["name"]))
+                        tk = sgtk.sgtk_from_entity("Project", cur_project["id"])
+                        proj_ctx = tk.context_from_entity("Project", cur_project["id"])
+                        __engine_refresh(proj_ctx)
+                        return
                 __create_tank_disabled_menu(e)
                 return
 

--- a/python/tk_nuke/__init__.py
+++ b/python/tk_nuke/__init__.py
@@ -201,7 +201,10 @@ def sgtk_on_load_callback():
                 if engine.get_setting("allow_keep_context_from_project"):
                     cur_project = engine.context.project
                     if cur_project:
-                        logger.debug("Trying to create context from Project '%s'" % (cur_project["name"]))
+                        logger.debug(
+                            "Trying to create context from Project '%s'"
+                            % (cur_project["name"])
+                        )
                         tk = sgtk.sgtk_from_entity("Project", cur_project["id"])
                         proj_ctx = tk.context_from_entity("Project", cur_project["id"])
                         __engine_refresh(proj_ctx)


### PR DESCRIPTION
This originally comes from this [PR ](https://github.com/shotgunsoftware/tk-nuke/pull/97), and aims to introduce a new engine setting that avoids the ShotGrid menu from being disabled when for example someone opens a file with Nuke's File --> Open, that does not reside in any known project path, allowing users to retain the Project context enabled so that the user can use the shotgrid workfiles app to save the current file into the pipeline.