### PR TITLE
SG-38376 Add support for Nuke 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-[![VFX Platform](https://img.shields.io/badge/vfxplatform-2025%20%7C%202024%20%7C%202023%20%7C%202022-blue.svg)](http://www.vfxplatform.com/)
-[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.10%20%7C%203.9-blue.svg)](https://www.python.org/)
+# Toolkit Engine for Nuke
+
+![Supported Nuke versions](https://img.shields.io/badge/Nuke-16_%7C_15_%7C_14-blue.svg?logo=nuke)
+[![Supported VFX Platform](https://img.shields.io/badge/VFX_Platform-2025_%7C_2024_%7C_2023_%7C_2022-blue.svg)](http://www.vfxplatform.com/)
+[![Supported Python versions](https://img.shields.io/badge/Python-3.11_%7C_3.10_%7C_3.9-blue.svg?logo=python)](https://www.python.org/)
+
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-nuke?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=83&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Toolkit Engine for Nuke
 
-![Supported Nuke versions](https://img.shields.io/badge/Nuke-16_|_15_|_14-blue.svg?logo=nuke "Supported Nuke versions")
-[![Supported VFX Platform](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue.svg)](http://www.vfxplatform.com/ "Supported VFX Platform")
-[![Supported Python versions](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue.svg?logo=python)](https://www.python.org/ "Supported Python versions")
+![Supported Nuke versions: 14 - 16](https://img.shields.io/badge/Nuke-16_|_15_|_14-blue.svg?logo=nuke "Supported Nuke versions")
+[![Supported VFX Platform: 2022 - 2025](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue)](http://www.vfxplatform.com/ "Supported VFX Platform")
+[![Supported Python versions: 3.9 - 3.11](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
 
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-nuke?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=83&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Toolkit Engine for Nuke
 
-![Supported Nuke versions](https://img.shields.io/badge/Nuke-16_%7C_15_%7C_14-blue.svg?logo=nuke)
-[![Supported VFX Platform](https://img.shields.io/badge/VFX_Platform-2025_%7C_2024_%7C_2023_%7C_2022-blue.svg)](http://www.vfxplatform.com/)
-[![Supported Python versions](https://img.shields.io/badge/Python-3.11_%7C_3.10_%7C_3.9-blue.svg?logo=python)](https://www.python.org/)
+![Supported Nuke versions](https://img.shields.io/badge/Nuke-16_|_15_|_14-blue.svg?logo=nuke "Supported Nuke versions")
+[![Supported VFX Platform](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue.svg)](http://www.vfxplatform.com/ "Supported VFX Platform")
+[![Supported Python versions](https://img.shields.io/badge/Python-3.11_%7C_3.10_%7C_3.9-blue.svg?logo=python)](https://www.python.org/ "Supported Python versions")
 
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-nuke?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=83&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Supported Nuke versions](https://img.shields.io/badge/Nuke-16_|_15_|_14-blue.svg?logo=nuke "Supported Nuke versions")
 [![Supported VFX Platform](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue.svg)](http://www.vfxplatform.com/ "Supported VFX Platform")
-[![Supported Python versions](https://img.shields.io/badge/Python-3.11_%7C_3.10_%7C_3.9-blue.svg?logo=python)](https://www.python.org/ "Supported Python versions")
+[![Supported Python versions](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue.svg?logo=python)](https://www.python.org/ "Supported Python versions")
 
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-nuke?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=83&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/engine.py
+++ b/engine.py
@@ -151,7 +151,7 @@ class NukeEngine(sgtk.platform.Engine):
 
         self.logger.debug("%s: Initializing...", self)
 
-        MAX_VERSION = (15, 1)  # untested above this so display a warning
+        MAX_VERSION = (16, 9)  # untested above this so display a warning
 
         import tk_nuke
 
@@ -168,11 +168,8 @@ class NukeEngine(sgtk.platform.Engine):
             nuke.env.get("NukeVersionRelease"),
         )
 
-        msg = "Nuke 7.0v10 is the minimum version supported!"
-        if nuke_version[0] < 7:
-            self.logger.error(msg)
-            return
-        elif nuke_version[0] == 7 and nuke_version[1] == 0 and nuke_version[2] < 10:
+        msg = "Nuke 13.0v1 is the minimum comptabile version!"
+        if nuke_version[0] < 13:
             self.logger.error(msg)
             return
 

--- a/info.yml
+++ b/info.yml
@@ -169,4 +169,4 @@ description: "Flow Production Tracking Integration in Nuke"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.20.30"
+requires_core_version: "v0.22.3"

--- a/info.yml
+++ b/info.yml
@@ -157,7 +157,7 @@ configuration:
                         it isn't yet fully supported and tested with Toolkit.  To disable the warning
                         dialog for the version you are testing, it is recommended that you set this
                         value to the current major version + 1."
-        default_value:  10
+        default_value:  16
 
 # the Shotgun fields that this engine needs in order to operate correctly
 requires_shotgun_fields:

--- a/startup.py
+++ b/startup.py
@@ -224,7 +224,7 @@ class NukeLauncher(SoftwareLauncher):
         """
         Minimum supported version by this launcher.
         """
-        return "7.0v10"
+        return "13.0v1"
 
     def prepare_launch(self, exec_path, args, file_to_open=None):
         """

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -32,6 +32,61 @@ class TestStartup(TankTestBase):
     # Mocked folder hierarchy for OSX
     _mac_mock_hierarchy = {
         "Applications": {
+            "Nuke16.0v1": [
+                "Hiero16.0v1.app",
+                "HieroPlayer16.0v1.app",
+                "Nuke16.0v1 Non-commercial.app",
+                "Nuke16.0v1.app",
+                "NukeAssist16.0v1.app",
+                "NukeStudio16.0v1 Non-commercial.app",
+                "NukeStudio16.0v1.app",
+                "NukeX16.0v1 Non-commercial.app",
+                "NukeX16.0v1.app",
+            ],
+            "Nuke15.1v2": [
+                "Hiero15.1v2.app",
+                "HieroPlayer15.1v2.app",
+                "Nuke15.1v2 Non-commercial.app",
+                "Nuke15.1v2.app",
+                "NukeAssist15.1v2.app",
+                "NukeStudio15.1v2 Non-commercial.app",
+                "NukeStudio15.1v2.app",
+                "NukeX15.1v2 Non-commercial.app",
+                "NukeX15.1v2.app",
+            ],
+            "Nuke14.0v8": [
+                "Hiero14.0v8.app",
+                "HieroPlayer14.0v8.app",
+                "Nuke14.0v8 Non-commercial.app",
+                "Nuke14.0v8.app",
+                "NukeAssist14.0v8.app",
+                "NukeStudio14.0v8 Non-commercial.app",
+                "NukeStudio14.0v8.app",
+                "NukeX14.0v8 Non-commercial.app",
+                "NukeX14.0v8.app",
+            ],
+            "Nuke13.0v9": [
+                "Hiero13.0v9.app",
+                "HieroPlayer13.0v9.app",
+                "Nuke13.0v9 Non-commercial.app",
+                "Nuke13.0v9.app",
+                "NukeAssist13.0v9.app",
+                "NukeStudio13.0v9 Non-commercial.app",
+                "NukeStudio13.0v9.app",
+                "NukeX13.0v9 Non-commercial.app",
+                "NukeX13.0v9.app",
+            ],
+            "Nuke12.2v5": [
+                "Hiero12.2v5.app",
+                "HieroPlayer12.2v5.app",
+                "Nuke12.2v5 Non-commercial.app",
+                "Nuke12.2v5.app",
+                "NukeAssist12.2v5.app",
+                "NukeStudio12.2v5 Non-commercial.app",
+                "NukeStudio12.2v5.app",
+                "NukeX12.2v5 Non-commercial.app",
+                "NukeX12.2v5.app",
+            ],
             "Nuke10.0v5": [
                 "Hiero10.0v5.app",
                 "HieroPlayer10.0v5.app",
@@ -85,6 +140,11 @@ class TestStartup(TankTestBase):
     _windows_mock_hiearchy = {
         "C:\\": {
             "Program Files": {
+                "Nuke16.0v1": ["Nuke16.0.exe"],
+                "Nuke15.1v2": ["Nuke15.1.exe"],
+                "Nuke14.0v8": ["Nuke14.0.exe"],
+                "Nuke13.0v9": ["Nuke13.0.exe"],
+                "Nuke12.2v5": ["Nuke12.5.exe"],
                 "Nuke10.0v5": ["Nuke10.0.exe"],
                 "Nuke9.0v8": ["Nuke9.0.exe"],
                 "Nuke8.0v4": ["Nuke8.0.exe"],
@@ -98,6 +158,11 @@ class TestStartup(TankTestBase):
     _linux_mock_hierarchy = {
         "usr": {
             "local": {
+                "Nuke16.0v1": ["Nuke16.0"],
+                "Nuke15.1v2": ["Nuke15.1"],
+                "Nuke14.0v8": ["Nuke14.0"],
+                "Nuke13.0v9": ["Nuke13.0"],
+                "Nuke12.2v5": ["Nuke12.5"],
                 "Nuke10.0v5": ["Nuke10.0"],
                 "Nuke9.0v8": ["Nuke9.0"],
                 "Nuke8.0v4": ["Nuke8.0"],
@@ -207,35 +272,91 @@ class TestStartup(TankTestBase):
         # is the same as os.listdir
         return list(self._glob_wrapper(directory, False))
 
+    def test_nuke16(self):
+        """
+        Ensures we are returning the right variants for Nuke 16.
+        """
+        self._test_nuke(
+            [
+                "Nuke 16.0v1",
+                "NukeX 16.0v1",
+                "NukeStudio 16.0v1",
+                "NukeAssist 16.0v1",
+            ],
+            "16.0v1",
+        )
+
+    def test_nuke15(self):
+        """
+        Ensures we are returning the right variants for Nuke 15.
+        """
+        self._test_nuke(
+            [
+                "Nuke 15.1v2",
+                "NukeX 15.1v2",
+                "NukeStudio 15.1v2",
+                "NukeAssist 15.1v2",
+            ],
+            "15.1v2",
+        )
+
+    def test_nuke14(self):
+        """
+        Ensures we are returning the right variants for Nuke 14.
+        """
+        self._test_nuke(
+            [
+                "Nuke 14.0v8",
+                "NukeX 14.0v8",
+                "NukeStudio 14.0v8",
+                "NukeAssist 14.0v8",
+            ],
+            "14.0v8",
+        )
+
+    def test_nuke13(self):
+        """
+        Ensures we are returning the right variants for Nuke 13.
+        """
+        self._test_nuke(
+            [
+                "Nuke 13.0v9",
+                "NukeX 13.0v9",
+                "NukeStudio 13.0v9",
+                "NukeAssist 13.0v9",
+            ],
+            "13.0v9",
+        )
+
+    def test_nuke12(self):
+        """
+        Ensures we are returning the right variants for Nuke 12.
+        """
+        self._test_nuke([], "12.2v5")
+
     def test_nuke10(self):
         """
         Ensures we are returning the right variants for Nuke 10.
         """
-        self._test_nuke(
-            ["Nuke 10.0v5", "NukeX 10.0v5", "NukeStudio 10.0v5", "NukeAssist 10.0v5"],
-            "10.0v5",
-        )
+        self._test_nuke([], "10.0v5")
 
     def test_nuke9(self):
         """
         Ensures we are returning the right variants for Nuke 9.
         """
-        self._test_nuke(
-            ["Nuke 9.0v8", "NukeX 9.0v8", "NukeStudio 9.0v8", "NukeAssist 9.0v8"],
-            "9.0v8",
-        )
+        self._test_nuke([], "9.0v8")
 
     def test_nuke8(self):
         """
         Ensures we are returning the right variants for Nuke 8.
         """
-        self._test_nuke(["Nuke 8.0v4", "NukeX 8.0v4", "NukeAssist 8.0v4"], "8.0v4")
+        self._test_nuke([], "8.0v4")
 
     def test_nuke7(self):
         """
         Ensures we are returning the right variants for Nuke 7.
         """
-        self._test_nuke(["Nuke 7.0v10", "NukeX 7.0v10", "NukeAssist 7.0v10"], "7.0v10")
+        self._test_nuke([], "7.0v10")
 
     def test_nuke7_9(self):
         """


### PR DESCRIPTION
Add support for Nuke 16

- Update newest supported version from `15.0+` to `16+` 
- Update oldest compatible version from `7.0v10` to `13.0v1`. Older versions are shipping Python 2.
- Update badges
- Update core version requirement to v0.22.3 to support Nuke 16
