### PR TITLE
SG-15664 Replace `imp`

### DIFF
--- a/plugins/basic/Python/Startup/__init__.py
+++ b/plugins/basic/Python/Startup/__init__.py
@@ -13,9 +13,10 @@ This file is being imported by Nuke Studio automatically because it is in the HI
 It launches the plugin's bootstrap process by reusing the one for Nuke.
 """
 
-import imp
 import uuid
 import os
+
+import importlib_wrapper
 
 
 def startup():
@@ -25,7 +26,7 @@ def startup():
     startup_root_path = os.path.dirname(__file__)
     module = None
     try:
-        module = imp.load_source(
+        module = importlib_wrapper.load_source(
             uuid.uuid4().hex,
             os.path.normpath(os.path.join(startup_root_path, "..", "..", "menu.py")),
         )

--- a/plugins/basic/Python/Startup/importlib_wrapper.py
+++ b/plugins/basic/Python/Startup/importlib_wrapper.py
@@ -1,0 +1,21 @@
+# Importlib wrapper for Python 3.11- compatibility.
+# This module provides a function to load a source file as a module,
+# mimicking the behavior of the `imp.load_source()` function.
+# It is intended to be used in environments where the `imp` module is deprecated
+# or removed, such as in Python 3.12 and later.
+# Taken from https://docs.python.org/3/whatsnew/3.12.html#imp
+
+import importlib.util
+import importlib.machinery
+from types import ModuleType
+
+
+def load_source(modname: str, filename: str) -> ModuleType:
+    loader = importlib.machinery.SourceFileLoader(modname, filename)
+    spec = importlib.util.spec_from_file_location(modname, filename, loader=loader)
+    module = importlib.util.module_from_spec(spec)
+    # The module is always executed and not cached in sys.modules.
+    # Uncomment the following line to cache the module.
+    # sys.modules[module.__name__] = module
+    loader.exec_module(module)
+    return module


### PR DESCRIPTION
This pull request updates the `plugins/basic/Python/Startup` module to replace the deprecated `imp` module with a custom `importlib_wrapper` for improved compatibility with Python 3.12 and later. The most important changes include the introduction of the `importlib_wrapper` module and modifications to the `startup` function to use it.
