### PR TITLE
SG-40015 Update SsoSaml2Core reference to explicit import for FPTR integration in Nuke

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -393,9 +393,9 @@ Please report any issues to:
         To avoid Nuke crash, a monkeypatch of on_dialog_closed is required,
         here the user is warned about restarted nuke is needed to continue.
         """
-        sgtk.authentication.sso_saml2.core.sso_saml2_core.SsoSaml2Core.on_dialog_closed = (
-            self._on_dialog_closed_monkeypatch
-        )
+        from sgtk.authentication.sso_saml2.core.sso_saml2_core import SsoSaml2Core
+
+        SsoSaml2Core.on_dialog_closed = self._on_dialog_closed_monkeypatch
 
     @staticmethod
     def _on_dialog_closed_monkeypatch(self, result):


### PR DESCRIPTION
### **Descrption**

The FPTR integration in Nuke was failing to launch due to a [change](https://github.com/shotgunsoftware/tk-core/pull/1022/commits/adff10f88c0e5b47fbabb32d97eaa92a6e720a34) in tk-core that removed the implicit import of SsoSaml2Core from authentication/sso_saml2/core/__init__.py.

This PR updates tk-nuke to import SsoSaml2Core explicitly from sgtk.authentication.sso_saml2.core.sso_saml2_core, removing the dependency on the previous implicit import and ensuring compatibility with the latest tk-core.

Important notes:

- [ ] IMPORTANT ❗  - This PR must not be merged until the new tk-core version greater than v0.22.5 is available, so that the info.yml update can be included in the same merge.

- [ ] After the next tk-core release greater than v0.22.5, an additional change will be required in info.yml to set the minimum required tk-core version to that release or newer.

### **Test**
<img width="1889" height="1042" alt="image" src="https://github.com/user-attachments/assets/a5fc3afd-5b32-4c69-adaa-d7ffebec2330" />
