### PR TITLE
SG-40319 Skip tests for Nuke versions lower than 10

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # Running the test suite
 
-Have tk-core in the same directory of tk-nuke. 
+Have tk-core in the same directory of tk-nuke.
 Then you just need to execute this on tk-nuke directory:
 
 ```bash

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -341,35 +341,45 @@ class TestStartup(TankTestBase):
         """
         self._test_nuke([], "10.0v5")
 
-    @skip("Skipping Nuke versions below 10 due to issues on string comparison because of distutils removal.")
+    @skip(
+        "Skipping Nuke versions below 10 due to issues on string comparison because of distutils removal."
+    )
     def test_nuke9(self):
         """
         Ensures we are returning the right variants for Nuke 9.
         """
         self._test_nuke([], "9.0v8")
 
-    @skip("Skipping Nuke versions below 10 due to issues on string comparison because of distutils removal.")
+    @skip(
+        "Skipping Nuke versions below 10 due to issues on string comparison because of distutils removal."
+    )
     def test_nuke8(self):
         """
         Ensures we are returning the right variants for Nuke 8.
         """
         self._test_nuke([], "8.0v4")
 
-    @skip("Skipping Nuke versions below 10 due to issues on string comparison because of distutils removal.")
+    @skip(
+        "Skipping Nuke versions below 10 due to issues on string comparison because of distutils removal."
+    )
     def test_nuke7(self):
         """
         Ensures we are returning the right variants for Nuke 7.
         """
         self._test_nuke([], "7.0v10")
 
-    @skip("Skipping Nuke versions below 10 due to issues on string comparison because of distutils removal.")
+    @skip(
+        "Skipping Nuke versions below 10 due to issues on string comparison because of distutils removal."
+    )
     def test_nuke7_9(self):
         """
         Ensures we are returning the right variants for Nuke 7.
         """
         self._test_nuke([], "7.0v9")
 
-    @skip("Skipping Nuke versions below 10 due to issues on string comparison because of distutils removal.")
+    @skip(
+        "Skipping Nuke versions below 10 due to issues on string comparison because of distutils removal."
+    )
     def test_nuke6(self):
         """
         Ensures that Nuke 6 or lower are not returned as they are not supported.


### PR DESCRIPTION
This pull request updates the test suite documentation and modifies the startup tests to address compatibility issues with older Nuke versions. The main changes focus on improving test reliability and clarity.

**Test suite documentation improvements:**

* Added instructions to `tests/README.md` for running the test suite, including prerequisites and the command to execute tests.

**Test reliability and compatibility:**

* Updated `tests/test_startup.py` to skip tests for Nuke versions below 10, due to string comparison issues caused by the removal of `distutils`. The `@skip` decorator is now used on all affected test cases. [[1]](diffhunk://#diff-4b20c5be1ae70d35e19ac5bdae8632443acc5ff3c9a28a8d21b7d241c370c66eR20) [[2]](diffhunk://#diff-4b20c5be1ae70d35e19ac5bdae8632443acc5ff3c9a28a8d21b7d241c370c66eR344-R372)