### PR TITLE
SG-42601 precommit and black updated

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ exclude: "ui\/.*py$|httplib.py|urllib2.py"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is has the correct syntax.
     - id: check-ast
@@ -37,6 +37,6 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.1.0
     hooks:
     - id: black

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+coverage:
+  status:
+    # Disable patch coverage check - engine.py contains imports and code
+    # that can only be executed inside Nuke DCC, which is not available in CI
+    patch:
+      default:
+        informational: true
+    project:
+      default:
+        # Allow small coverage variations without failing the build
+        threshold: 0.5%
+        base: auto
+        only_pulls: true

--- a/engine.py
+++ b/engine.py
@@ -15,7 +15,6 @@ import os
 import nukescripts
 import logging
 
-
 # Nuke versions compatibility constants
 VERSION_OLDEST_COMPATIBLE = (13, 0, 1)
 VERSION_OLDEST_SUPPORTED = (14, 0, 8)
@@ -89,7 +88,7 @@ class NukeEngine(sgtk.platform.Engine):
     """
 
     # Define the different areas where menu events can occur in Hiero.
-    (HIERO_BIN_AREA, HIERO_SPREADSHEET_AREA, HIERO_TIMELINE_AREA) = range(3)
+    HIERO_BIN_AREA, HIERO_SPREADSHEET_AREA, HIERO_TIMELINE_AREA = range(3)
 
     def __init__(self, *args, **kwargs):
         # For the short term, we will treat Nuke Studio as if it

--- a/hooks/tk-multi-publish2/basic/collector.py
+++ b/hooks/tk-multi-publish2/basic/collector.py
@@ -343,7 +343,7 @@ class NukeSessionCollector(HookBaseClass):
             version_number = render_path_fields.get("version")
 
             # use the path basename and nuke writenode name for display
-            (_, filename) = os.path.split(publish_path)
+            _, filename = os.path.split(publish_path)
             display_name = "%s (%s)" % (publish_name, node.name())
 
             # create and populate the item

--- a/hooks/tk-multi-publish2/basic/nuke_publish_script.py
+++ b/hooks/tk-multi-publish2/basic/nuke_publish_script.py
@@ -84,9 +84,7 @@ class NukeSessionPublishPlugin(HookBaseClass):
         however only the most recent publish will be available to other users.
         Warnings will be provided during validation if there are previous
         publishes.
-        """ % (
-            loader_url,
-        )
+        """ % (loader_url,)
 
     @property
     def settings(self):
@@ -248,13 +246,13 @@ class NukeSessionPublishPlugin(HookBaseClass):
         # check to see if the next version of the work file already exists on
         # disk. if so, warn the user and provide the ability to save to the next
         # available version now
-        (next_version_path, version) = self._get_next_version_info(path, item)
+        next_version_path, version = self._get_next_version_info(path, item)
         if next_version_path and os.path.exists(next_version_path):
 
             # determine the next available version_number. just keep asking for
             # the next one until we get one that doesn't exist.
             while os.path.exists(next_version_path):
-                (next_version_path, version) = self._get_next_version_info(
+                next_version_path, version = self._get_next_version_info(
                     next_version_path, item
                 )
 

--- a/hooks/tk-multi-publish2/basic/nukestudio_publish_project.py
+++ b/hooks/tk-multi-publish2/basic/nukestudio_publish_project.py
@@ -84,9 +84,7 @@ class NukeStudioProjectPublishPlugin(HookBaseClass):
         however only the most recent publish will be available to other users.
         Warnings will be provided during validation if there are previous
         publishes.
-        """ % (
-            loader_url,
-        )
+        """ % (loader_url,)
         # TODO: add link to workflow docs
 
     @property
@@ -256,13 +254,13 @@ class NukeStudioProjectPublishPlugin(HookBaseClass):
         # check to see if the next version of the work file already exists on
         # disk. if so, warn the user and provide the ability to jump to save
         # to that version now
-        (next_version_path, version) = self._get_next_version_info(path, item)
+        next_version_path, version = self._get_next_version_info(path, item)
         if next_version_path and os.path.exists(next_version_path):
 
             # determine the next available version_number. just keep asking for
             # the next one until we get one that doesn't exist.
             while os.path.exists(next_version_path):
-                (next_version_path, version) = self._get_next_version_info(
+                next_version_path, version = self._get_next_version_info(
                     next_version_path, item
                 )
 

--- a/hooks/tk-multi-publish2/basic/submit_for_review.py
+++ b/hooks/tk-multi-publish2/basic/submit_for_review.py
@@ -51,9 +51,7 @@ class NukeSubmitForReviewPlugin(HookBaseClass):
         created in Flow Production Tracking which will include a reference to the movie file's
         current path on disk. Other users will be able to access the file via
         the <b><a href='%s'>review app</a></b> on the Flow Production Tracking website.</p>
-        """ % (
-            review_url
-        )
+        """ % (review_url)
 
     @property
     def settings(self):

--- a/plugins/basic/menu.py
+++ b/plugins/basic/menu.py
@@ -13,7 +13,6 @@ This file is being imported by Nuke automatically because it is in the NUKE_PATH
 It launches the plugin's bootstrap process.
 """
 
-
 import os
 import sys
 

--- a/python/tk_nuke/__init__.py
+++ b/python/tk_nuke/__init__.py
@@ -17,6 +17,7 @@ not necessarily fully initialized. Therefore, any modules that require
 QT to be imported should be placed in the tk_nuke_qt module instead
 in order to avoid import errors at startup and context switch.
 """
+
 import os
 import textwrap
 import nuke
@@ -70,7 +71,7 @@ def __create_tank_error_menu():
     Creates a std "error" tank menu and grabs the current context.
     Make sure that this is called from inside an except clause.
     """
-    (exc_type, exc_value, exc_traceback) = sys.exc_info()
+    exc_type, exc_value, exc_traceback = sys.exc_info()
     message = ""
     message += "PTR encountered a problem starting the Engine. "
     message += "Please contact us via %s\n\n" % sgtk.support_url

--- a/python/tk_nuke/menu_generation.py
+++ b/python/tk_nuke/menu_generation.py
@@ -72,7 +72,7 @@ class BaseMenuGenerator(object):
         """
         Creates an "error" menu item.
         """
-        (exc_type, exc_value, exc_traceback) = sys.exc_info()
+        exc_type, exc_value, exc_traceback = sys.exc_info()
         msg = (
             "Message: PTR encountered a problem starting the Engine.\n"
             "Exception: %s - %s\n"

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -20,7 +20,6 @@ from unittest import mock
 from unittest import skip
 import contextlib
 
-
 repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 print("tk-nuke repository root found at %s." % repo_root)
 


### PR DESCRIPTION
This pull request primarily includes updates to third-party tool versions and minor code cleanups to improve readability and maintain consistency. The most significant changes are grouped below:

Dependency Updates:

* Updated the `pre-commit-hooks` repository version from `v5.0.0` to `v6.0.0` and the `black` formatter version from `25.1.0` to `26.1.0` in `.pre-commit-config.yaml` for improved linting and formatting support. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L22-R22) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L40-R40)

Code Cleanups and Consistency Improvements:

* Replaced tuple unpacking parentheses with direct assignment in several places for improved code readability and consistency, including menu area definitions in `engine.py`, file path handling in collector and validation hooks, and error handling in Python scripts. [[1]](diffhunk://#diff-773b7e340b77c3c54109da863b41163ac971f899da59d8efcbfba7ce8a9c7e88L92-R91) [[2]](diffhunk://#diff-024d8fcd4bf9a8e35b5fcb151ba8926c3b973eae806de6092d9f8c5f0f97a920L346-R346) [[3]](diffhunk://#diff-c132b9fa035707ca6631ff91fca670930061383a4fc2782d8472cc127547b899L251-R255) [[4]](diffhunk://#diff-e22057715612795848e61ba24f23329a36b3e4840a0b2aa5b58ce702cd72421bL259-R263) [[5]](diffhunk://#diff-1792e42c3389fd3ca5a4165f6b22729e598b5b43d76a69f606c00f1c74d2c837L73-R74) [[6]](diffhunk://#diff-1eac920580d0b074fbd8664044e42f51536b8b379e02f141cb9e6f44a4402ccaL75-R75)
* Simplified string formatting by removing unnecessary parentheses in docstrings and descriptions across multiple publish and review hooks. [[1]](diffhunk://#diff-c132b9fa035707ca6631ff91fca670930061383a4fc2782d8472cc127547b899L87-R87) [[2]](diffhunk://#diff-e22057715612795848e61ba24f23329a36b3e4840a0b2aa5b58ce702cd72421bL87-R87) [[3]](diffhunk://#diff-b61f80f9dada9dbbb319584639e148389bd8021ad5eedc59336639f151f95dc0L54-R54)
* Removed extraneous blank lines in several files to maintain code cleanliness, such as `engine.py`, `plugins/basic/menu.py`, `tests/test_startup.py`, and added a blank line for clarity in `python/tk_nuke/__init__.py`. [[1]](diffhunk://#diff-773b7e340b77c3c54109da863b41163ac971f899da59d8efcbfba7ce8a9c7e88L18) [[2]](diffhunk://#diff-dab5e98f6b29f8ee2d11cfff3cf0100cc6b81b55abeaae025ce552a996cd728fL16) [[3]](diffhunk://#diff-4b20c5be1ae70d35e19ac5bdae8632443acc5ff3c9a28a8d21b7d241c370c66eL23) [[4]](diffhunk://#diff-1792e42c3389fd3ca5a4165f6b22729e598b5b43d76a69f606c00f1c74d2c837R20)