### PR TITLE
SG-42791 supported nuke 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Toolkit Engine for Nuke
 
-![Supported Nuke versions: 14.0v8 - 16.0v1](https://img.shields.io/badge/Nuke-14.0v16_--_16.0v1-blue.svg?logo=nuke "Supported Nuke versions")
-[![Supported VFX Platform: 2022 - 2025](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue)](http://www.vfxplatform.com/ "Supported VFX Platform")
-[![Supported Python versions: 3.9 - 3.11](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
+![Supported Nuke versions: 15.0v1 - 17.0v1](https://img.shields.io/badge/Nuke-14.0v16_--_16.0v1-blue.svg?logo=nuke "Supported Nuke versions")
+[![Supported VFX Platform: CY2022 - CY2026](https://img.shields.io/badge/VFX_Reference_Platform-CY2022_|_CY2023_|_CY2024_|_CY2025_|_CY2026-blue)](http://www.vfxplatform.com/ "Supported VFX Reference Platform versions")
+[![Supported Python versions: 3.9, 3.10, 3.11, 3.13](https://img.shields.io/badge/Python-3.9_|_3.10_|_3.11_|_3.13-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
 
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-nuke?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=83&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/engine.py
+++ b/engine.py
@@ -16,9 +16,9 @@ import nukescripts
 import logging
 
 # Nuke versions compatibility constants
-VERSION_OLDEST_COMPATIBLE = (13, 0, 1)
-VERSION_OLDEST_SUPPORTED = (14, 0, 8)
-VERSION_NEWEST_SUPPORTED = (16, 0, 99)
+VERSION_OLDEST_COMPATIBLE = (14, 0, 1)
+VERSION_OLDEST_SUPPORTED = (15, 0, 8)
+VERSION_NEWEST_SUPPORTED = (17, 0, 99)
 # Caution: make sure compatibility_dialog_min_version default value in info.yml
 # is equal to VERSION_NEWEST_SUPPORTED
 

--- a/info.yml
+++ b/info.yml
@@ -157,7 +157,7 @@ configuration:
                         it isn't yet fully supported and tested with Toolkit.  To disable the warning
                         dialog for the version you are testing, it is recommended that you set this
                         value to the current major version + 1."
-        default_value:  16
+        default_value:  17
 
 # the Shotgun fields that this engine needs in order to operate correctly
 requires_shotgun_fields:

--- a/startup.py
+++ b/startup.py
@@ -15,7 +15,7 @@ import pprint
 from sgtk.platform import SoftwareLauncher, SoftwareVersion, LaunchInformation
 
 # Nuke versions compatibility constants
-VERSION_OLDEST_COMPATIBLE = (13, 0, 1)
+VERSION_OLDEST_COMPATIBLE = (14, 0, 1)
 
 
 class NukeLauncher(SoftwareLauncher):

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -32,6 +32,17 @@ class TestStartup(TankTestBase):
     # Mocked folder hierarchy for OSX
     _mac_mock_hierarchy = {
         "Applications": {
+            "Nuke17.0v1": [
+                "Hiero17.0v1.app",
+                "HieroPlayer17.0v1.app",
+                "Nuke17.0v1 Non-commercial.app",
+                "Nuke17.0v1.app",
+                "NukeAssist17.0v1.app",
+                "NukeStudio17.0v1 Non-commercial.app",
+                "NukeStudio17.0v1.app",
+                "NukeX17.0v1 Non-commercial.app",
+                "NukeX17.0v1.app",
+            ],
             "Nuke16.0v1": [
                 "Hiero16.0v1.app",
                 "HieroPlayer16.0v1.app",
@@ -140,6 +151,7 @@ class TestStartup(TankTestBase):
     _windows_mock_hiearchy = {
         "C:\\": {
             "Program Files": {
+                "Nuke17.0v1": ["Nuke17.0.exe"],
                 "Nuke16.0v1": ["Nuke16.0.exe"],
                 "Nuke15.1v2": ["Nuke15.1.exe"],
                 "Nuke14.0v8": ["Nuke14.0.exe"],
@@ -158,7 +170,7 @@ class TestStartup(TankTestBase):
     _linux_mock_hierarchy = {
         "usr": {
             "local": {
-                "Nuke16.0v1": ["Nuke16.0"],
+                "Nuke17.0v1": ["Nuke17.0"],
                 "Nuke15.1v2": ["Nuke15.1"],
                 "Nuke14.0v8": ["Nuke14.0"],
                 "Nuke13.0v9": ["Nuke13.0"],
@@ -272,6 +284,20 @@ class TestStartup(TankTestBase):
         # is the same as os.listdir
         return list(self._glob_wrapper(directory, False))
 
+    def test_nuke17(self):
+        """
+        Ensures we are returning the right variants for Nuke 16.
+        """
+        self._test_nuke(
+            [
+                "Nuke 17.0v1",
+                "NukeX 17.0v1",
+                "NukeStudio 17.0v1",
+                "NukeAssist 17.0v1",
+            ],
+            "17.0v1",
+        )
+
     def test_nuke16(self):
         """
         Ensures we are returning the right variants for Nuke 16.
@@ -318,15 +344,7 @@ class TestStartup(TankTestBase):
         """
         Ensures we are returning the right variants for Nuke 13.
         """
-        self._test_nuke(
-            [
-                "Nuke 13.0v9",
-                "NukeX 13.0v9",
-                "NukeStudio 13.0v9",
-                "NukeAssist 13.0v9",
-            ],
-            "13.0v9",
-        )
+        self._test_nuke([], "13.0v9")
 
     def test_nuke12(self):
         """

--- a/tests/test_startup.py
+++ b/tests/test_startup.py
@@ -171,6 +171,7 @@ class TestStartup(TankTestBase):
         "usr": {
             "local": {
                 "Nuke17.0v1": ["Nuke17.0"],
+                "Nuke16.0v1": ["Nuke16.0"],
                 "Nuke15.1v2": ["Nuke15.1"],
                 "Nuke14.0v8": ["Nuke14.0"],
                 "Nuke13.0v9": ["Nuke13.0"],


### PR DESCRIPTION
This pull request updates the compatibility and supported version information for the Nuke Toolkit Engine. The changes ensure that the engine reflects support for newer Nuke, VFX Reference Platform, and Python versions, and updates internal constants and configuration to match. These updates are important for keeping the engine aligned with current industry standards and supported environments.

**Compatibility and Supported Versions Update:**

* Updated the supported Nuke versions in the `README.md` badge and documentation to reflect support for versions 15.0v1 through 17.0v1, and updated the VFX Reference Platform and Python version badges to include the latest supported versions.
* Changed the version compatibility constants in `engine.py` to set `VERSION_OLDEST_COMPATIBLE` to 14.0.1, `VERSION_OLDEST_SUPPORTED` to 15.0.8, and `VERSION_NEWEST_SUPPORTED` to 17.0.99.
* Updated the `VERSION_OLDEST_COMPATIBLE` constant in `startup.py` to 14.0.1.
* Set the default value for the compatibility dialog minimum version in `info.yml` to 17, aligning with the new supported Nuke versions.