### PR TITLE
SG-37411 - Fix for Nuke Windows path issue

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ resources:
     - repository: templates
       type: github
       name: shotgunsoftware/tk-ci-tools
-      ref: refs/heads/master
+      ref: refs/heads/ticket/SG-43246-fix-ci
       endpoint: shotgunsoftware
 
 # We want builds to trigger for 3 reasons:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ resources:
     - repository: templates
       type: github
       name: shotgunsoftware/tk-ci-tools
-      ref: refs/heads/ticket/SG-43246-fix-ci
+      ref: refs/heads/master
       endpoint: shotgunsoftware
 
 # We want builds to trigger for 3 reasons:

--- a/engine.py
+++ b/engine.py
@@ -916,6 +916,11 @@ Please report any issues to:
         """
         import hiero
 
+        # Hiero/Nuke re-evaluates stored knob and export-template strings through TCL,
+        # which strips single backslashes (e.g. "Q:\Project" -> "Q:Project"). Pass the
+        # path with forward slashes so it survives round-tripping on Windows.
+        project_path = self.sgtk.project_path.replace("\\", "/")
+
         for p in hiero.core.projects():
             # In Nuke 11 and greater the Project.projectRoot and Project.setProjectRoot methods
             # have been deprecated in favour of Project.exportRootDirectory and
@@ -924,14 +929,14 @@ Please report any issues to:
                 self.logger.debug(
                     "Setting exportRootDirectory on %s to: %s",
                     p.name(),
-                    self.sgtk.project_path,
+                    project_path,
                 )
-                p.setProjectDirectory(self.sgtk.project_path)
+                p.setProjectDirectory(project_path)
             elif nuke.env.get("NukeVersionMajor") <= 10 and not p.projectRoot():
                 self.logger.debug(
-                    "Setting projectRoot on %s to: %s", p.name(), self.sgtk.project_path
+                    "Setting projectRoot on %s to: %s", p.name(), project_path
                 )
-                p.setProjectRoot(self.sgtk.project_path)
+                p.setProjectRoot(project_path)
 
     def _get_dialog_parent(self):
         """
@@ -1120,6 +1125,10 @@ Please report any issues to:
                 # Remove old directory
                 nuke.removeFavoriteDir(dir_name)
 
+                # Favorites persist to ~/.nuke/folders.nk as a TCL script, which strips
+                # single backslashes on re-evaluation. Use forward slashes on Windows.
+                root_path = root_path.replace("\\", "/")
+
                 # Add new path
                 nuke.addFavoriteDir(
                     dir_name,
@@ -1149,6 +1158,9 @@ Please report any issues to:
             icon_path = favorite.get("icon")
             if not os.path.isfile(icon_path) or not os.path.exists(icon_path):
                 icon_path = sg_logo
+
+            # See note above re: ~/.nuke/folders.nk TCL evaluation.
+            path = path.replace("\\", "/")
 
             nuke.addFavoriteDir(
                 favorite["display_name"],

--- a/engine.py
+++ b/engine.py
@@ -916,11 +916,6 @@ Please report any issues to:
         """
         import hiero
 
-        # Hiero/Nuke re-evaluates stored knob and export-template strings through TCL,
-        # which strips single backslashes (e.g. "Q:\Project" -> "Q:Project"). Pass the
-        # path with forward slashes so it survives round-tripping on Windows.
-        project_path = self.sgtk.project_path.replace("\\", "/")
-
         for p in hiero.core.projects():
             # In Nuke 11 and greater the Project.projectRoot and Project.setProjectRoot methods
             # have been deprecated in favour of Project.exportRootDirectory and
@@ -929,14 +924,14 @@ Please report any issues to:
                 self.logger.debug(
                     "Setting exportRootDirectory on %s to: %s",
                     p.name(),
-                    project_path,
+                    self.sgtk.project_path,
                 )
-                p.setProjectDirectory(project_path)
+                p.setProjectDirectory(self.sgtk.project_path)
             elif nuke.env.get("NukeVersionMajor") <= 10 and not p.projectRoot():
                 self.logger.debug(
-                    "Setting projectRoot on %s to: %s", p.name(), project_path
+                    "Setting projectRoot on %s to: %s", p.name(), self.sgtk.project_path
                 )
-                p.setProjectRoot(project_path)
+                p.setProjectRoot(self.sgtk.project_path)
 
     def _get_dialog_parent(self):
         """
@@ -1125,10 +1120,6 @@ Please report any issues to:
                 # Remove old directory
                 nuke.removeFavoriteDir(dir_name)
 
-                # Favorites persist to ~/.nuke/folders.nk as a TCL script, which strips
-                # single backslashes on re-evaluation. Use forward slashes on Windows.
-                root_path = root_path.replace("\\", "/")
-
                 # Add new path
                 nuke.addFavoriteDir(
                     dir_name,
@@ -1158,9 +1149,6 @@ Please report any issues to:
             icon_path = favorite.get("icon")
             if not os.path.isfile(icon_path) or not os.path.exists(icon_path):
                 icon_path = sg_logo
-
-            # See note above re: ~/.nuke/folders.nk TCL evaluation.
-            path = path.replace("\\", "/")
 
             nuke.addFavoriteDir(
                 favorite["display_name"],


### PR DESCRIPTION
**Summary:**
Fix Windows paths becoming corrupted when tk-nuke passes them to Hiero/Nuke
APIs that store the path through TCL. Single backslashes (`\P`, `\Y`, etc.)
are stripped on re-evaluation, so `Q:\Project` round-trips as `Q:Project`.

Fixes:  [SG-37411](https://jira.autodesk.com/browse/SG-37411) Forward-slash Windows paths sent to Nuke/Hiero APIs

**Root Cause of issue:**
Hiero and Nuke re-evaluate stored knob and export-template strings through TCL, which strips single backslashes ("Q:\Project" -> "Q:Project"). With a Local Storage of "Q:/", Hiero's project.projectDirectory(True) returned a corrupted path on Windows, breaking exports and file dialogs.

**Solution:**
Convert paths to forward slashes at the engine -> Nuke/Hiero boundary where they enter TCL-evaluated contexts:

- set_project_root: normalize sgtk.project_path before passing to setProjectDirectory()/setProjectRoot(). This is the path with a reproducible client report.

- __setup_favorite_dirs: normalize root_path and resolved template paths before nuke.addFavoriteDir(). Defense-in-depth; same boundary, same risk surface if/when API-added favorites ever get persisted to ~/.nuke/folders.nk.

Nuke/Hiero accept forward slashes on Windows in all of these contexts, so the conversion is safe and avoids touching tk-core's _sanitize_path (which would have site-wide blast radius).

**Applicable (tested) Scenarios:**
Precondition - set Local Storage in SG to a forward slash drive (e.g. "Q:/")

1. In Hiero, querying project root gives the correct path using script below.  (e.g. "Q:/Project")
```
import hiero.core
p = hiero.core.projects()[-1]
print(repr(p.exportRootDirectory()))
```

2. In Nuke Studio, same as above.
3. In basic Nuke, default favourite folder in the Open dialog has the correct path when hovering over the folder.
<img width="848" height="410" alt="image" src="https://github.com/user-attachments/assets/c8d99d23-52ce-4012-8679-35ee7b1af6b3" />

4. After adding a template directory under _favorite_directories_ setting in Nuke config
e.g.
```
favourite_directories:
  - display_name: "Shot Work Area (Nuke)"
    template_directory: shot_work_area_nuke
    icon: ""
```
And opening up the correct context for that template dir to appear in favourites in the Open dialog, hovering over the folder should show the correct resolved path.
<img width="844" height="411" alt="image" src="https://github.com/user-attachments/assets/8645af04-5009-4cb9-80a0-41049bd32797" />

In all scenarios, we are specifically making sure that the local storage path resolves correctly with a forward slash after the drive letter.  (e.g. "Q:/Project...")