### PR TITLE
SG-43666 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,6 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black

--- a/info.yml
+++ b/info.yml
@@ -170,3 +170,4 @@ description: "Flow Production Tracking Integration in Nuke"
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.22.6"
+minimum_python_version: "3.9"


### PR DESCRIPTION
## Summary

- Set `minimum_python_version: "3.9"` in `info.yml`

## Test plan

- [ ] Engine loads correctly on Python 3.9+

🤖 Generated with [Claude Code](https://claude.com/claude-code)